### PR TITLE
Update the dask executor layer

### DIFF
--- a/src/test.yaml
+++ b/src/test.yaml
@@ -12,3 +12,16 @@ runner:
 executor:
   type: DaskExecutor
   base_run_dir: /scratch/project_2007159/cursed-tglf/trial_dask
+  worker_args: # to be specified for the SLURMCluster in DASK
+    account: "project_2005083"
+    queue: "medium"
+    cores: 1 
+    memory: "12GB"
+    processes: 1
+    walltime: "00:10:00" # Adam: survival length of worker, so possibly just set to max in cluster
+    interface: "ib0"
+    job_script_prologue: # this is possibly dependent on which code you want
+      - 'module load python-data'
+      - 'cd /scratch/project_2007159/cursed-tglf/'
+      - 'export PYTHONPATH=$PYTHONPATH:/scratch/project_2007159/cursed-tglf/src' # NB: to use the enchanted-surrogate library
+  num_workers: 12


### PR DESCRIPTION
In the dask executor, wanted to move the cluster/worker arguments away from hardcoding and add comments to the configuration file. 