### PR TITLE
Making base executor more general so I can make a non dask executor to run on LUMI

### DIFF
--- a/src/executors/DaskExecutor.py
+++ b/src/executors/DaskExecutor.py
@@ -3,6 +3,8 @@
 from dask.distributed import Client
 from dask_jobqueue import SLURMCluster
 from .base import Executor
+from .base import run_simulation_task
+from dask.distributed import as_completed
 
 
 class DaskExecutor(Executor):
@@ -21,3 +23,39 @@ class DaskExecutor(Executor):
         self.cluster.scale(self.num_workers)
         self.client = Client(self.cluster)
         print('Finished Setup')
+
+    def start_runs(self):
+        print(100 * "=")
+        print("Starting Database generation")
+        print("Creating initial runs")
+        futures = []
+
+        # TODO: implement get_initial_parameters() from sampler
+        for _ in range(self.sampler.num_initial_points):
+            params = self.sampler.get_next_parameter()
+            new_future = self.client.submit(
+                run_simulation_task, self.runner_args, params, self.base_run_dir
+            )
+            futures.append(new_future)
+
+        print("Starting search")
+        seq = as_completed(futures)
+        completed = 0
+        for future in seq:
+            res = future.result()
+            completed += 1
+            print(res, completed)
+            # TODO: is this waiting for an open node or are we just
+            # pushing to queue?
+            if self.max_samples > completed:
+                # TODO: pass the previous result and parameters..
+                # For active learning
+                params = self.sampler.get_next_parameter()
+                if params is None:  # This is hacky
+                    continue
+                else:
+                    new_future = self.client.submit(
+                        run_simulation_task, self.runner_args, params, self.base_run_dir
+                    )
+                    seq.add(new_future)
+

--- a/src/executors/LocalDaskExecutor.py
+++ b/src/executors/LocalDaskExecutor.py
@@ -2,6 +2,8 @@
 
 from dask.distributed import Client
 from .base import Executor
+from dask.distributed import as_completed
+from .base import run_simulation_task
 
 
 class LocalDaskExecutor(Executor):
@@ -14,3 +16,38 @@ class LocalDaskExecutor(Executor):
         # n_workers=2, threads_per_worker=4
         self.client = Client()
         print('Finished Setup')
+
+    def start_runs(self):
+        print(100 * "=")
+        print("Starting Database generation")
+        print("Creating initial runs")
+        futures = []
+
+        # TODO: implement get_initial_parameters() from sampler
+        for _ in range(self.sampler.num_initial_points):
+            params = self.sampler.get_next_parameter()
+            new_future = self.client.submit(
+                run_simulation_task, self.runner_args, params, self.base_run_dir
+            )
+            futures.append(new_future)
+
+        print("Starting search")
+        seq = as_completed(futures)
+        completed = 0
+        for future in seq:
+            res = future.result()
+            completed += 1
+            print(res, completed)
+            # TODO: is this waiting for an open node or are we just
+            # pushing to queue?
+            if self.max_samples > completed:
+                # TODO: pass the previous result and parameters..
+                # For active learning
+                params = self.sampler.get_next_parameter()
+                if params is None:  # This is hacky
+                    continue
+                else:
+                    new_future = self.client.submit(
+                        run_simulation_task, self.runner_args, params, self.base_run_dir
+                    )
+                    seq.add(new_future)

--- a/src/executors/base.py
+++ b/src/executors/base.py
@@ -6,15 +6,13 @@ import uuid
 from dask.distributed import as_completed
 import runners
 
-
 def run_simulation_task(runner_args, params_from_sampler, base_run_dir):
-    print("Making Run dir")
-    run_dir = os.path.join(base_run_dir, str(uuid.uuid4()))
-    os.mkdir(run_dir)
-    runner = getattr(runners, runner_args["type"])(**runner_args)
-    result = runner.single_code_run(params_from_sampler, run_dir)
-    return result, params_from_sampler
-
+        print("Making Run dir")
+        run_dir = os.path.join(base_run_dir, str(uuid.uuid4()))
+        os.mkdir(run_dir)
+        runner = getattr(runners, runner_args["type"])(**runner_args)
+        result = runner.single_code_run(params_from_sampler, run_dir)
+        return result, params_from_sampler
 
 class Executor(ABC):
     def __init__(
@@ -69,3 +67,5 @@ class Executor(ABC):
                         run_simulation_task, self.runner_args, params, self.base_run_dir
                     )
                     seq.add(new_future)
+
+    

--- a/src/executors/base.py
+++ b/src/executors/base.py
@@ -3,7 +3,6 @@ import os
 import shutil
 from abc import ABC
 import uuid
-from dask.distributed import as_completed
 import runners
 
 def run_simulation_task(runner_args, params_from_sampler, base_run_dir):
@@ -33,39 +32,5 @@ class Executor(ABC):
 
         shutil.copyfile(config_filepath, os.path.join(self.base_run_dir, "CONFIG.yaml"))
 
-    def start_runs(self):
-        print(100 * "=")
-        print("Starting Database generation")
-        print("Creating initial runs")
-        futures = []
-
-        # TODO: implement get_initial_parameters() from sampler
-        for _ in range(self.sampler.num_initial_points):
-            params = self.sampler.get_next_parameter()
-            new_future = self.client.submit(
-                run_simulation_task, self.runner_args, params, self.base_run_dir
-            )
-            futures.append(new_future)
-
-        print("Starting search")
-        seq = as_completed(futures)
-        completed = 0
-        for future in seq:
-            res = future.result()
-            completed += 1
-            print(res, completed)
-            # TODO: is this waiting for an open node or are we just
-            # pushing to queue?
-            if self.max_samples > completed:
-                # TODO: pass the previous result and parameters..
-                # For active learning
-                params = self.sampler.get_next_parameter()
-                if params is None:  # This is hacky
-                    continue
-                else:
-                    new_future = self.client.submit(
-                        run_simulation_task, self.runner_args, params, self.base_run_dir
-                    )
-                    seq.add(new_future)
-
+    
     


### PR DESCRIPTION
I am having a problem that I cannot get dask to run on LUMI. I have decided to switch to a new tactic of using the scanning feature of GENE. SO I am writing a new executor and parser in order to make this happen.

When I went to make an executor I noticed there is dask implimented in the start_runs function in the base class. I didn't want my child class to inherit any dask stuff, so I moved start_runs into the dask executor. Then I can create my own executor with it's own start_runs that doesn't have any dask in it. I also put start_runs in the local_dask_executor and imported some needed functions. 

Since this might have a merge conflict and affect your code I wanted to try and merge it to main as soon as possible.

I hope this is okay.