### PR TITLE
Improve Error output when the simulator_run fails within a dask worker

### DIFF
--- a/src/executors/base.py
+++ b/src/executors/base.py
@@ -21,7 +21,7 @@ import shutil
 from abc import ABC, abstractmethod
 import uuid
 import runners
-
+import traceback
 from dask.distributed import print
 
 # TODO: move to seperate file, tasks.py?
@@ -53,7 +53,8 @@ def run_simulation_task(
         result = {"input": params_from_sampler, "output": runner_output}
     except Exception as exc:
         print("="*100,f"\nThere was a Python error on a DASK worker when running a simulation task:\n{exc}", flush=True)
-
+        #print the whole traceback and not just the last error
+        print(traceback.format_exc())
     return result
 
 

--- a/src/executors/base.py
+++ b/src/executors/base.py
@@ -22,6 +22,7 @@ from abc import ABC, abstractmethod
 import uuid
 import runners
 
+from dask.distributed import print
 
 # TODO: move to seperate file, tasks.py?
 def run_simulation_task(
@@ -43,11 +44,16 @@ def run_simulation_task(
         FileNotFoundError: If the base_run_dir does not exist and cannot be created.
         Exception: For other exceptions that may arise during the simulation run.
     """
-    run_dir = os.path.join(base_run_dir, str(uuid.uuid4()))
-    os.mkdir(run_dir)
-    runner = getattr(runners, runner_args["type"])(**runner_args)
-    runner_output = runner.single_code_run(params_from_sampler, run_dir)
-    result = {"input": params_from_sampler, "output": runner_output}
+
+    try:
+        run_dir = os.path.join(base_run_dir, str(uuid.uuid4()))
+        os.mkdir(run_dir)
+        runner = getattr(runners, runner_args["type"])(**runner_args)
+        runner_output = runner.single_code_run(params_from_sampler, run_dir)
+        result = {"input": params_from_sampler, "output": runner_output}
+    except Exception as exc:
+        print("="*100,f"\nThere was a Python error on a DASK worker when running a simulation task:\n{exc}", flush=True)
+
     return result
 
 

--- a/src/executors/base.py
+++ b/src/executors/base.py
@@ -55,6 +55,7 @@ def run_simulation_task(
         print("="*100,f"\nThere was a Python error on a DASK worker when running a simulation task:\n{exc}", flush=True)
         #print the whole traceback and not just the last error
         print(traceback.format_exc())
+        return None
     return result
 
 

--- a/src/executors/base.py
+++ b/src/executors/base.py
@@ -55,7 +55,7 @@ def run_simulation_task(
         print("="*100,f"\nThere was a Python error on a DASK worker when running a simulation task:\n{exc}", flush=True)
         #print the whole traceback and not just the last error
         print(traceback.format_exc())
-        return None
+        result = None
     return result
 
 

--- a/src/executors/base.py
+++ b/src/executors/base.py
@@ -52,9 +52,8 @@ def run_simulation_task(
         runner_output = runner.single_code_run(params_from_sampler, run_dir)
         result = {"input": params_from_sampler, "output": runner_output}
     except Exception as exc:
-        print("="*100,f"\nThere was a Python error on a DASK worker when running a simulation task:\n{exc}", flush=True)
+        print("="*100,f"\nThere was a Python ERROR on a DASK worker when running a simulation task:\n{exc}\n",traceback.format_exc(), flush=True)
         #print the whole traceback and not just the last error
-        print(traceback.format_exc())
         result = None
     return result
 


### PR DESCRIPTION
Previously, when `run_simulation_task` was called within a DASK worker, there was a possibility that a run failed (for a given runner/parser combo) due to some error in the runner (it could be python or could be not happy handling of exits by a code),  and it was difficult to trace the error via STD out, as the worker would just fail, and the nanny would keep existing. 

now `run_simulation_task`  prints errors to std out(which can be found in the sbatch out file) instead of cryptically failing. 