### PR TITLE
Move makedirs out from the runners and into the simulation task.

### DIFF
--- a/src/enchanted_surrogates/executors/simulation_task.py
+++ b/src/enchanted_surrogates/executors/simulation_task.py
@@ -11,6 +11,7 @@ def run_simulation_task(runner_kwargs:dict, run_dir:str, params: dict=None, futu
     Returns:
     Raises:
     """
+    os.makedirs(run_dir, exist_ok=True)
     runner_type = runner_kwargs['type']
     runner = import_runner(type=runner_type, runner_kwargs=runner_kwargs)
     try:            

--- a/src/enchanted_surrogates/runners/example_runner.py
+++ b/src/enchanted_surrogates/runners/example_runner.py
@@ -7,7 +7,6 @@ class ExampleRunner(Runner):
     def single_code_run(self, run_dir: str, params: dict = None) -> dict:
         # Implementation for the example runner
         # Logic should follow something like
-        # - create the run directory
         # - via parser, write some input files there
         # - run the code
         # - return outputs
@@ -18,7 +17,6 @@ class ExampleRunner(Runner):
         #     will be collected and available in enchanted surrogates created datasets.
         #   - for the datasets to be created properly the return dictionary values should not be
         #     iterables, only base types such as int, float, string, boolean...
-        os.makedirs(run_dir, exist_ok=True)
 
         # TODO make example parser
         # parser.write_input(run_dir, params)


### PR DESCRIPTION
The run directory name is already created by the executor. The creation of the directory is now in simulation task instead of the runners. If it is in the runner, then each runner just has to contain the same line of code. Also adding that would be easy to miss for new users when they are creating a runner.