### PR TITLE
Fixing the list of imports in the example BO parser

### DIFF
--- a/src/enchanted_surrogates/parsers/example_bayesian_optimization_parser.py
+++ b/src/enchanted_surrogates/parsers/example_bayesian_optimization_parser.py
@@ -1,14 +1,5 @@
 import os
 import numpy as np
-from matplotlib.colors import LinearSegmentedColormap
-import scipy.stats as stats
-import scipy.io as sio
-from scipy.interpolate import interp1d
-from sklearn.metrics import mean_absolute_error
-from skimage import transform, feature
-import matplotlib.pyplot as plt
-import h5py
-import pickle as pkl
 import pandas as pd
 
 from enchanted_surrogates.parsers.base_parser import Parser


### PR DESCRIPTION
There was a stack of legacy imports from the DREAM parser that are not needed by the example. I deleted those. That is the only change. 