### PR TITLE
feature/error_handeling

### DIFF
--- a/src/enchanted_surrogates/executors/dask_executor.py
+++ b/src/enchanted_surrogates/executors/dask_executor.py
@@ -331,7 +331,7 @@ TO AVOID THIS PLEASE ISSUE INCLUDE ANY TIMEOUTS IN YOUR RUNNER AND HANDLE EARLY 
                     shutil.rmtree(batch_dir)
                     break
                 
-                _futures = self.submit_batch(samples, base_run_dir=batch_dir, request_errors=True, rm_run_dir=~self.save_run_dirs)
+                _futures = self.submit_batch(samples, base_run_dir=batch_dir, request_errors=True)
                 futures = set(_futures)
                 del _futures
                 num_samp_in_batch = len(futures)
@@ -430,7 +430,7 @@ TO AVOID THIS PLEASE ISSUE INCLUDE ANY TIMEOUTS IN YOUR RUNNER AND HANDLE EARLY 
                 sample_run_dir = make_run_dir(base_run_dir=base_run_dir, prepend=self.runner_config['type']) 
             run_dirs.append(sample_run_dir)
             new_future = client.submit(
-                run_simulation_task, self.runner_config, sample_run_dir, sample_params, return_errors=request_errors, retries=0
+                run_simulation_task, self.runner_config, sample_run_dir, sample_params, return_errors=request_errors, rm_run_dir=~self.save_run_dirs, retries=0
             )
             futures.append(new_future)
             fut_to_rundir[new_future.key] = sample_run_dir

--- a/src/enchanted_surrogates/executors/dask_executor.py
+++ b/src/enchanted_surrogates/executors/dask_executor.py
@@ -1,16 +1,25 @@
 import os
+#!/usr/bin/env python3
+import glob
+import os
+            
 import subprocess
 import time
 import warnings
 import pandas as pd
+import json
 
 from dask_jobqueue import SLURMCluster
 from dask.distributed import LocalCluster
 from dask.distributed import Client, as_completed, wait, LocalCluster, get_worker, get_client
 from dask.distributed import print as dask_print
+from enchanted_surrogates.utils.time_format import format_sec
+
+from enchanted_surrogates.utils.precise_imports import import_runner
 
 from .base_executor import Executor
 from enchanted_surrogates.executors import simulation_task
+import shutil
 from enchanted_surrogates.utils.make_run_dir import make_run_dir
 from enchanted_surrogates.utils.precise_imports import import_sampler
 
@@ -51,18 +60,33 @@ class DaskExecutor(Executor):
         super().__init__(*args, **kwargs)
         print('INITIALISING DASK EXECUTOR')
         self.type = kwargs.get('type')
+        self.base_run_dir = kwargs.get('base_run_dir')
+        self.sampler_config = kwargs.get('sampler_config')
         if self.sampler_config:
+            self.sampler_config['base_run_dir'] = self.base_run_dir
             self.sampler_type = self.sampler_config.pop("type")
-            self.sampler = import_sampler(
-                type=self.sampler_type, sampler_config=self.sampler_config)
-        self.scale_n_jobs = kwargs.get('scale_n_jobs', 1)
+            self.sampler = import_sampler(type=self.sampler_type, sampler_config=self.sampler_config)
+        self.scale_n_jobs = kwargs.get('scale_n_jobs', None)
+        self.scale_n_jobs_min = kwargs.get('scale_n_jobs_min', None)
+        self.scale_n_jobs_max = kwargs.get('scale_n_jobs_max', None)
+        assert not (self.scale_n_jobs and (self.scale_n_jobs_min or self.scale_n_jobs_max)), 'EITHER scale_n_jobs OR scale_n_jobs_min/scale_n_jobs_max CAN BE SET, NOT BOTH'
+        
+        self.runner_config = kwargs.get('runner_config')
+        
         self.timeout = kwargs.get('timeout', 1e10)
+        self.run_error_log_path = os.path.join(self.base_run_dir, 'runs_error_log.jsonl')
         self.SLURMcluster_config = kwargs.get('SLURMcluster_config')
         self.LocalCluster_config = kwargs.get('LocalCluster_config')
         self.block_until_cluster_started = kwargs.get('block_until_cluster_started', False)  # for debugging purposes only
         self.cluster = None
         self.client = None
         self.expected_number_of_workers = None
+        self.current_batch = 0
+        self.save_run_dirs = kwargs.get('save_run_dirs', True)
+        self.submit_command = kwargs.get('submit_command', None)
+        
+        self.psudo_runner = import_runner(self.runner_config['type'], runner_config=self.runner_config)
+
 
     def start_cluster(self, slurm_out_dir=None):
         """
@@ -79,14 +103,9 @@ class DaskExecutor(Executor):
             Warning: If fewer workers than expected are started.
         """
         print('MAKING CLUSTER')
-        worker_logs_dir = None
-
         if self.SLURMcluster_config:
-            self.expected_number_of_workers = self.scale_n_jobs * int(self.SLURMcluster_config.get('processes',1))
-
             if not slurm_out_dir:
                 slurm_out_dir = os.path.join(self.base_run_dir,'worker_out_DaskExecutor')
-            worker_logs_dir = slurm_out_dir
             if not os.path.exists(slurm_out_dir):
                 os.makedirs(slurm_out_dir)
             jed = self.SLURMcluster_config.get('job_extra_directives')
@@ -96,7 +115,18 @@ class DaskExecutor(Executor):
                 self.SLURMcluster_config['job_extra_directives']+=[f'-o {slurm_out_dir}/%x.%j.out',f'-e {slurm_out_dir}/%x.%j.err']    
             print('FOR WORKER SLURM OUT, SEE:',slurm_out_dir)
             self.cluster = SLURMCluster(**self.SLURMcluster_config)
-            self.cluster.scale(self.scale_n_jobs)
+            
+            if self.submit_command:
+                self.cluster.job_cls.submit_command = self.submit_command
+            
+            if self.scale_n_jobs:
+                self.cluster.scale(self.scale_n_jobs)
+            elif self.scale_n_jobs_min and self.scale_n_jobs_max:
+                self.cluster.adapt(minimum=self.scale_n_jobs_min, maximum=self.scale_n_jobs_max)
+            else:
+                self.cluster.scale(1)  # Default to 1 worker if no scaling info provided
+                
+            
             print('THE JOB SCRIPT FOR A WORKER IS:')
             print(self.cluster.job_script())
             
@@ -114,6 +144,7 @@ class DaskExecutor(Executor):
             self.client = Client(self.cluster)
             
         if self.block_until_cluster_started:
+            self.expected_number_of_workers = self.scale_n_jobs * int(self.SLURMcluster_config.get('processes',1))
             print(f"Waiting for {self.expected_number_of_workers} workers to start...")
             for i in range(1,self.expected_number_of_workers+2):
                 if i == self.expected_number_of_workers+1:
@@ -134,6 +165,10 @@ class DaskExecutor(Executor):
                 print(f"  CPUs: {info['nthreads']}")
                 print(f"  Memory: {info['memory_limit'] / 1e9:.2f} GB")
                 print(f"  Resources: {info.get('resources', {})}\n")
+        
+        bash_command = "scancel $(squeue -u $USER -o '%i %j' | awk '$2 ~ /dask/ {print $1}')"
+        print(f"**TOP TIP** USE THIS SLURM BASH COMMAND TO CANCEL ALL JOBS WITH dask IN THE NAME\n{bash_command}")
+
 
     def wait_for_all_dask_jobs_running(self, poll_interval=1):
         """
@@ -219,11 +254,6 @@ class DaskExecutor(Executor):
                 count += 1
         return num_alive_workers
 
-    def scale(self, num_workers):
-        if self.count_alive_workers == self.scale_n_jobs:
-            self.cluster.scale(num_workers)
-        self.scale_n_jobs = num_workers
-
     def start_runs(self):
         """
         Starts the execution of simulation tasks using the configured Dask cluster.
@@ -242,7 +272,11 @@ class DaskExecutor(Executor):
         if not os.path.exists(self.base_run_dir):
             print('MAKING BASE RUN DIR:',self.base_run_dir)
             os.makedirs(self.base_run_dir)
-
+        
+        if hasattr(self.psudo_runner,'light_pre_processing'):
+            print('PERFORMING LIGHT PRE PROCESSING FROM THE RUNNER:',self.runner_config['type'])
+            self.psudo_runner.light_pre_processing(self.base_run_dir)
+        
         if self.sampler_type not in {'BayesianOptimizationSampler'}:
             if os.path.exists(os.path.join(self.base_run_dir, 'ENCHANTED.FINISHED')):
                 raise FileExistsError(f'''The file: {self.base_run_dir}/ENCHANTED.FINISHED, exists.
@@ -254,46 +288,103 @@ class DaskExecutor(Executor):
         if not self.client:
             self.start_cluster()
         print('CLUSTER STARTED')
-        all_futures = []
 
+        print(f'SAMPLER: {self.sampler_type}')
+        enchanted_dataset_path_success = os.path.join(self.base_run_dir, 'enchanted_dataset.csv')
+        enchanted_dataset_path_fail = os.path.join(self.base_run_dir, 'enchanted_dataset_fail.csv')
+        completed = 0
+        all_success = 0
         while self.sampler.has_budget:
-            samples = self.sampler.get_next_samples()
-            futures = self.submit_batch(samples)
+            print(f'SAMPLER: {self.sampler_type} | BATCH:{self.current_batch}')
+            
             if self.sampler_type in {'BayesianOptimizationSampler'}:
+                samples = self.sampler.get_next_samples()
+                futures = self.submit_batch(samples, base_run_dir=self.base_run_dir, request_errors=True)
+                print(f"Launching {len(futures)} samples")
+
                 try: 
                     wait(futures, timeout=self.timeout)
                 except:
-                    print("TIMEOUT OF SOME OF THE SAMPLES")
-            all_futures.extend(futures)
-        print(f'{len(all_futures)} FUTURES HAVE BEEN SENT')
-        dfs = []
-        num_success = 0
-        if self.sampler_type in {'BayesianOptimizationSampler'}:
-            try: 
-                wait(futures, timeout=self.timeout)
-                if self.sampler.plot_GPR_flag:
-                    # Build the result dictionary and set plot frequency to 1 to 
-                    # plot the GPR for the final state of the optimization.
-                    # Plotting is presently implemented in the train_surrogate function.
-                    self.sampler.build_result_dictionary(self.sampler.base_run_dir)
-                    self.sampler.plot_frequency = 1
-                    self.sampler.train_surrogate()
-            except:
-                print("Timeout of some of the samples")
-        else:
-            for i, future in enumerate(as_completed(all_futures)):
-                result = future.result()
-                if result['success'] == True:
-                    num_success += 1
-                # print('FUTURE RESULT',result, type(result))
-                result = {k:[v] for k,v in result.items()}
-                dfs.append(pd.DataFrame(result))
-                print(f"[{i}/{len(all_futures)}] Futures Completed ({(i/len(all_futures))*100:.1f}%)","|",f"[{num_success}/{len(all_futures)}] Futures Succeded ({(num_success/len(all_futures))*100:.1f}%)")
-                print('_'*100)
-            df_dataset = pd.concat(dfs)
-            df_dataset.to_csv(os.path.join(self.base_run_dir, 'enchanted_dataset.csv'), index=False)
+                    warnings.warn(f'''SOME SAMPLES DID NOT FINISH IN THE TIMEOUT [{self.timeout}sec]\n
+THESE SAMPLES WILL CONTINUE RUNNING ON THE WORKER, CONSUMING RESOURCES AND BLOCKING FUTURE TASKS.
+IF EVENTUALLY COMPLETED THESE WORKERS MAY OR MAY NOT BE INCLUDED IN ANY DATASET OR ACTIVE LEARNING PROCESS CARRIED OUT BY ENCHANTED SURROGATES.
+TO AVOID THIS PLEASE ISSUE INCLUDE ANY TIMEOUTS IN YOUR RUNNER AND HANDLE EARLY ENDING/KILLING OF YOUR CODE THERE AND DO NOT SET DaskExecutor.timeout''')
+                
 
-        print('WALLTIME FOR ENCHANTED SURROGATES:', time.time()-start,'sec')
+            else: 
+                batch_dir = os.path.join(self.base_run_dir,f'batch_{self.current_batch}')
+                enchanted_dataset_batch_path_success = os.path.join(batch_dir,'enchanted_dataset.csv')
+                enchanted_dataset_batch_path_fail = os.path.join(batch_dir,'enchanted_dataset_fail.csv')
+
+                if not os.path.exists(batch_dir):
+                    print('MAKING BATCH DIR:',batch_dir)
+                    os.makedirs(batch_dir)        
+                samples = self.sampler.get_next_samples()
+                if not samples:
+                    print("SAMPLER DID NOT RETURN ANY SAMPLES, EXITING")
+                    shutil.rmtree(batch_dir)
+                    break
+                if self.sampler.submitted > self.sampler.budget:
+                    print(f'BUDGET REACHED | SUBMITTED={self.sampler.submitted} | BUDGET={self.sampler.budget} | EXITING')
+                    shutil.rmtree(batch_dir)
+                    break
+                
+                _futures = self.submit_batch(samples, base_run_dir=batch_dir, request_errors=True)
+                futures = set(_futures)
+                del _futures
+                num_samp_in_batch = len(futures)
+                print(f"Launching {len(futures)} samples")
+
+                dfs = []
+                num_success = 0
+                for i, future in enumerate(as_completed(futures)):
+                    result, error_info = future.result()
+                    completed += 1
+                    if result['success'] == True:
+                        num_success += 1
+                        all_success += 1
+                    if error_info is not None:
+                        with open(self.run_error_log_path, "a") as f:
+                            f.write(json.dumps(error_info) + "\n")
+
+                    # print('FUTURE RESULT',result, type(result))
+                    success = result['success']
+                    result = {k:[v] for k,v in result.items()}
+                    result['batch_num'] = self.current_batch
+                    dfi = pd.DataFrame(result)
+                    dfs.append(dfi)
+                    
+                    print('debug result success,', result['success'])
+                    if success:
+                        if os.path.exists(enchanted_dataset_batch_path_success):
+                            dfi.to_csv(enchanted_dataset_batch_path_success, mode='a', header=False, index=False)
+                        else:
+                            dfi.to_csv(enchanted_dataset_batch_path_success, mode='w', header=True, index=False)
+
+                        if os.path.exists(enchanted_dataset_path_success):
+                            dfi.to_csv(enchanted_dataset_path_success, mode='a', header=False, index=False)
+                        else:
+                            dfi.to_csv(enchanted_dataset_path_success, mode='w', header=True, index=False)
+                    else:
+                        if os.path.exists(enchanted_dataset_batch_path_fail):
+                            dfi.to_csv(enchanted_dataset_batch_path_fail, mode='a', header=False, index=False)
+                        else:
+                            dfi.to_csv(enchanted_dataset_batch_path_fail, mode='w', header=True, index=False)
+
+                        if os.path.exists(enchanted_dataset_path_fail):
+                            dfi.to_csv(enchanted_dataset_path_fail, mode='a', header=False, index=False)
+                        else:
+                            dfi.to_csv(enchanted_dataset_path_fail, mode='w', header=True, index=False)
+                        
+
+                    print(f"{'_'*100}\nBATCH {self.current_batch}| [{i+1}/{num_samp_in_batch}] Futures Completed ({((i+1)/num_samp_in_batch)*100:.1f}%)","|",f"[{num_success}/{num_samp_in_batch}] Futures Succeded ({(num_success/num_samp_in_batch)*100:.1f}%)")
+                    print(f"\n TOTAL | [{completed}/{self.sampler.budget}] Futures Completed ({(completed/self.sampler.budget)*100:.1f}%)","|",f"[{all_success}/{self.sampler.budget}] Futures Succeded ({(all_success/self.sampler.budget)*100:.1f}%)")
+                    print(f"TIME PASSED: {format_sec(time.time()-start)} d - hh:mm:ss \n {'_'*100}")
+                    futures.remove(future)
+                    
+            self.current_batch += 1
+        
+        print('WALLTIME FOR ENCHANTED SURROGATES:', format_sec(time.time()-start),'d h:m:s')
         if self.sampler_type not in {'BayesianOptimizationSampler'}:
             print('DATASET IS WRITTEN HERE:',os.path.join(self.base_run_dir, 'enchanted_dataset.csv'))
         print('WRITTING ENCHANTED.FINISHED FILE, SEE base_run_dir:',self.base_run_dir)
@@ -301,9 +392,12 @@ class DaskExecutor(Executor):
             file.write(f'ENCHANTED.FINISHED, {__class__}')
         print('CLUSTER SHUTDOWN')
         self.shutdown_cluster()
+        
+        if hasattr(self.psudo_runner,'light_post_processing'):
+            print('PERFORMING LIGHT POST PROCESSING FROM THE RUNNER:',self.runner_config['type'])
+            self.psudo_runner.light_post_processing(self.base_run_dir)
 
-
-    def submit_batch(self, samples, base_run_dir=None, client=None, include_fut_to_rundir=False):
+    def submit_batch(self, samples, base_run_dir=None, client=None, include_fut_to_rundir=False, request_errors=False):
         """
         Submits a batch of simulation tasks to the Dask cluster.
 
@@ -328,10 +422,13 @@ class DaskExecutor(Executor):
         run_dirs = []
         fut_to_rundir = {}
         for sample_params in samples:
-            sample_run_dir = make_run_dir(base_run_dir=base_run_dir, prepend=self.runner_config['type']) 
+            if not self.save_run_dirs:
+                sample_run_dir = make_run_dir(base_run_dir='/tmp/', prepend=self.runner_config['type']) 
+            else:
+                sample_run_dir = make_run_dir(base_run_dir=base_run_dir, prepend=self.runner_config['type']) 
             run_dirs.append(sample_run_dir)
             new_future = client.submit(
-                run_simulation_task, self.runner_config, sample_run_dir, sample_params
+                run_simulation_task, self.runner_config, sample_run_dir, sample_params, return_errors=request_errors, retries=0
             )
             futures.append(new_future)
             fut_to_rundir[new_future.key] = sample_run_dir

--- a/src/enchanted_surrogates/executors/dask_executor.py
+++ b/src/enchanted_surrogates/executors/dask_executor.py
@@ -331,7 +331,7 @@ TO AVOID THIS PLEASE ISSUE INCLUDE ANY TIMEOUTS IN YOUR RUNNER AND HANDLE EARLY 
                     shutil.rmtree(batch_dir)
                     break
                 
-                _futures = self.submit_batch(samples, base_run_dir=batch_dir, request_errors=True)
+                _futures = self.submit_batch(samples, base_run_dir=batch_dir, request_errors=True, rm_run_dir=~self.save_run_dirs)
                 futures = set(_futures)
                 del _futures
                 num_samp_in_batch = len(futures)

--- a/src/enchanted_surrogates/executors/dask_executor.py
+++ b/src/enchanted_surrogates/executors/dask_executor.py
@@ -144,27 +144,30 @@ class DaskExecutor(Executor):
             self.client = Client(self.cluster)
             
         if self.block_until_cluster_started:
-            self.expected_number_of_workers = self.scale_n_jobs * int(self.SLURMcluster_config.get('processes',1))
-            print(f"Waiting for {self.expected_number_of_workers} workers to start...")
-            for i in range(1,self.expected_number_of_workers+2):
-                if i == self.expected_number_of_workers+1:
-                    timeout_ = 3
-                    try:
-                        self.client.wait_for_workers(i, timeout=timeout_)
-                        warnings.warn(f'MORE WORKERS WERE STARTED THAN THE EXPECTED {self.expected_number_of_workers}')
-                    except TimeoutError:
-                        print(f"IN {timeout_} SEC NO UNEXPECTED WORKERS WERE STARTED.\n")
-                else:
-                    self.client.wait_for_workers(i, timeout=self.expected_number_of_workers+120)
-                    print(f"Connected to {i} workers out of expected {self.expected_number_of_workers}.\n")
-                
-            workers = self.client.scheduler_info()["workers"]            
-            print('SOME WORKER INFORMATION:')
-            for addr, info in workers.items():
-                print(f"Worker {addr}:")
-                print(f"  CPUs: {info['nthreads']}")
-                print(f"  Memory: {info['memory_limit'] / 1e9:.2f} GB")
-                print(f"  Resources: {info.get('resources', {})}\n")
+            if self.scale_n_jobs:
+                self.expected_number_of_workers = self.scale_n_jobs
+                print(f"Waiting for {self.expected_number_of_workers} workers to start...")
+                for i in range(1,self.expected_number_of_workers+2):
+                    if i == self.expected_number_of_workers+1:
+                        timeout_ = 3
+                        try:
+                            self.client.wait_for_workers(i, timeout=timeout_)
+                            warnings.warn(f'MORE WORKERS WERE STARTED THAN THE EXPECTED {self.expected_number_of_workers}')
+                        except TimeoutError:
+                            print(f"IN {timeout_} SEC NO UNEXPECTED WORKERS WERE STARTED.\n")
+                    else:
+                        self.client.wait_for_workers(i, timeout=self.expected_number_of_workers+120)
+                        print(f"Connected to {i} workers out of expected {self.expected_number_of_workers}.\n")
+                    
+                workers = self.client.scheduler_info()["workers"]            
+                print('SOME WORKER INFORMATION:')
+                for addr, info in workers.items():
+                    print(f"Worker {addr}:")
+                    print(f"  CPUs: {info['nthreads']}")
+                    print(f"  Memory: {info['memory_limit'] / 1e9:.2f} GB")
+                    print(f"  Resources: {info.get('resources', {})}\n")
+            else: 
+                warnings.warn('BLOCK UNTIL CLUSTER STARTED WAS True BUT scale_n_jobs WAS NOT DEFINED SO expected_number_of_workers COULD NOT BE DEFINED AND THE BLOCK WAS SKIPPED')
         
         bash_command = "scancel $(squeue -u $USER -o '%i %j' | awk '$2 ~ /dask/ {print $1}')"
         print(f"**TOP TIP** USE THIS SLURM BASH COMMAND TO CANCEL ALL JOBS WITH dask IN THE NAME\n{bash_command}")

--- a/src/enchanted_surrogates/executors/dask_executor.py
+++ b/src/enchanted_surrogates/executors/dask_executor.py
@@ -1,8 +1,4 @@
-import os
-#!/usr/bin/env python3
-import glob
-import os
-            
+import os            
 import subprocess
 import time
 import warnings
@@ -83,6 +79,9 @@ class DaskExecutor(Executor):
         self.expected_number_of_workers = None
         self.current_batch = 0
         self.save_run_dirs = kwargs.get('save_run_dirs', True)
+        if not self.save_run_dirs:
+            warnings.warn('PLEASE DO NOT SET save_run_dirs TO False WHEN YOU ARE RUNNING ON PARTIAL NODES, AS THE run_dirs ARE PUT IN /tmp/ WHICH IS OFTEN ON LOCAL NODE STORAGE AND IF FILLED CAN DISRUPT OTHER USERS RUNS. \nSETTING save_run_dirs TO False WILL MEAN ALL YOUR RUN DATA WILL BE DELETED EXCEPT WHAT IS PARSED AND RETURNED BY YOUR RUNNER. ')
+        
         self.submit_command = kwargs.get('submit_command', None)
         
         self.psudo_runner = import_runner(self.runner_config['type'], runner_config=self.runner_config)

--- a/src/enchanted_surrogates/executors/dask_nested_executor.py
+++ b/src/enchanted_surrogates/executors/dask_nested_executor.py
@@ -179,18 +179,6 @@ class DaskNestedExecutor(Executor):
                                 previous_success = True
                                 print(f'{datetime.now()} ONE FUTURE HAS COMPLETED WITH SUCCESS FOR NESTED DEPTH:',i-1)
                         time.sleep(1)
-                        # if all(done_status):
-                        #     prelim_results = [self.get_result(future, timeout=2, silent=False)[0] for future in self.all_futures[i-1]]
-                        #     suc = [] 
-                        #     for pr in prelim_results:
-                        #         if pr:
-                        #             suc.append(pr['success'])
-                        #     if not any(suc):
-                        #         print(f'THERE HAS BEEN NO SUCESSFULL FUTURES AT DEPTH: {i-1}')
-                        #         print('SHUTTING DOWN DASK WORKERS')
-                        #         self.clean()
-                        #         raise RuntimeError(f'THERE HAS BEEN NO SUCESSFULL FUTURES AT DEPTH: {i-1}')
-
                 
                 print(f"{datetime.now()} STARTING CLUSTER: {i} FOR {executor.runner_config['type']}")
                 # start cluster or assign client when reusing

--- a/src/enchanted_surrogates/executors/dask_nested_executor.py
+++ b/src/enchanted_surrogates/executors/dask_nested_executor.py
@@ -2,6 +2,7 @@
 TODO: Add module docstring
 """
 import os
+import json
 import time
 import warnings
 import pandas as pd
@@ -30,6 +31,7 @@ class DaskNestedExecutor(Executor):
         print('INITIALISING NESTED EXECUTOR')
         self.type = kwargs.get('type')
         self.base_run_dir=base_run_dir
+        self.run_error_log_path = os.path.join(self.base_run_dir, 'runs_error_log.jsonl')
         self.executor_names = list(executors.keys())
         self.executors_config = list(executors.values())
         self.executor_types = [exe_config['type'] for exe_config in self.executors_config]
@@ -152,7 +154,7 @@ class DaskNestedExecutor(Executor):
                 unique_df = self.current_samples_df.drop_duplicates(subset=sampler_i_params)
                 filtered_df = unique_df[sampler_i_params]
                 sampler_i_samples = filtered_df.to_dict(orient="records")
-                futures, fut_to_rundir = self.executors[i].submit_batch(sampler_i_samples, base_run_dir=batch_dir, include_fut_to_rundir=True)
+                futures, fut_to_rundir = self.executors[i].submit_batch(sampler_i_samples, base_run_dir=batch_dir, include_fut_to_rundir=True, request_errors=True)
                 self.all_futures[i].extend(futures)
                 self.all_fut_to_rundir.update(fut_to_rundir)
             else:
@@ -168,7 +170,7 @@ class DaskNestedExecutor(Executor):
                     while not previous_success:
                         done_status = [future.done() for future in self.all_futures[i-1]]
                         if any(done_status):
-                            prelim_results = [self.get_result(future, timeout=2, silent=False) for future in self.all_futures[i-1]]
+                            prelim_results = [self.get_result(future, timeout=2, silent=False)[0] for future in self.all_futures[i-1]]
                             suc = [] 
                             for pr in prelim_results:
                                 if pr:
@@ -177,6 +179,18 @@ class DaskNestedExecutor(Executor):
                                 previous_success = True
                                 print(f'{datetime.now()} ONE FUTURE HAS COMPLETED WITH SUCCESS FOR NESTED DEPTH:',i-1)
                         time.sleep(1)
+                        # if all(done_status):
+                        #     prelim_results = [self.get_result(future, timeout=2, silent=False)[0] for future in self.all_futures[i-1]]
+                        #     suc = [] 
+                        #     for pr in prelim_results:
+                        #         if pr:
+                        #             suc.append(pr['success'])
+                        #     if not any(suc):
+                        #         print(f'THERE HAS BEEN NO SUCESSFULL FUTURES AT DEPTH: {i-1}')
+                        #         print('SHUTTING DOWN DASK WORKERS')
+                        #         self.clean()
+                        #         raise RuntimeError(f'THERE HAS BEEN NO SUCESSFULL FUTURES AT DEPTH: {i-1}')
+
                 
                 print(f"{datetime.now()} STARTING CLUSTER: {i} FOR {executor.runner_config['type']}")
                 # start cluster or assign client when reusing
@@ -190,14 +204,28 @@ class DaskNestedExecutor(Executor):
                 done = [fut for fut in futures_check.values() if fut.done()]
                 while futures_check:
                     for j, future in enumerate(done):
-                        result = self.get_result(future, timeout=5)
-                        if not result:
+                        result= self.get_result(future, timeout=5)
+                        if result == (None, None):
                             continue
+                        result, error_info = result
                         self.update_completion_stats(result, i-1)
-                        # if self.do_dynamic_scale_down:
-                        #     self.dynamic_scale_down(exe_i=i-1, batch_num=batch_num)
+
+                        if error_info is not None:
+                            with open(self.run_error_log_path, "a") as f:
+                                f.write(json.dumps(error_info) + "\n")
+
                         futures_check.pop(future.key)
                         run_dir = result['run_dir']
+                        if not result['success']:
+                            enchanted_dataset_fail_path = os.path.join(os.path.dirname(run_dir), f'enchanted_dataset_fail_{i-1}.csv')
+                            dfi = pd.DataFrame({r:[v] for r,v in result.items()})
+                            if os.path.exists(enchanted_dataset_fail_path):
+                                dfi.to_csv(enchanted_dataset_fail_path, mode='a', header=False, index=False)
+                            else:
+                                dfi.to_csv(enchanted_dataset_fail_path, mode='w', header=True, index=False)
+                            continue
+                        # if self.do_dynamic_scale_down:
+                        #     self.dynamic_scale_down(exe_i=i-1, batch_num=batch_num)
                         previous_sample = {k: result[k] for k in previous_sampler_params if k in result}
                         # first filter for all the samples that have the same parameters as the previous sample
                         mask = pd.Series(True, index=self.current_samples_df.index)
@@ -208,7 +236,8 @@ class DaskNestedExecutor(Executor):
                         # Then filter to remove duplicates in the parameters for the current sampler
                         unique_df = filtered_df.drop_duplicates(subset=sampler_i_params)
                         filtered_df = unique_df[sampler_cumulative_params]
-                        extra_df = pd.DataFrame([result] * len(filtered_df))
+                        filtered_result = {k: v for k, v in result.items() if k not in ['success', 'run_dir', 'error_id']}
+                        extra_df = pd.DataFrame([filtered_result] * len(filtered_df))
                         filtered_df = filtered_df.reset_index(drop=True)
                         for col in extra_df.columns:
                             if col in filtered_df.columns:
@@ -221,7 +250,7 @@ class DaskNestedExecutor(Executor):
                             dfi.to_csv(enchanted_dataset_path, mode='a', header=False, index=False)
                         else:
                             dfi.to_csv(enchanted_dataset_path, mode='w', header=True, index=False)
-                        sub_futures, fut_to_rundir = self.executors[i].submit_batch(sampler_i_samples, base_run_dir=run_dir, include_fut_to_rundir=True)
+                        sub_futures, fut_to_rundir = self.executors[i].submit_batch(sampler_i_samples, base_run_dir=run_dir, include_fut_to_rundir=True, request_errors=True)
                         self.all_futures[i].extend(sub_futures)
                         self.all_fut_to_rundir.update(fut_to_rundir)
                         # this should shut down clusters when they have finished being used. Not to be used when doing active learning
@@ -233,35 +262,53 @@ class DaskNestedExecutor(Executor):
                     if all(cluster_status) and not i-1 in self.keep_alive:
                         print(f'CLOSING WORKERS FOR EXECUTOR: {i-1}')
                         self.executors[i-1].clean()
-                            
+                        
         # write the results for the last set of futures.
         base_enchanted_dataset_path = os.path.join(self.base_run_dir, f'enchanted_dataset.csv')
+        base_enchanted_dataset_fail_path = os.path.join(self.base_run_dir, f'enchanted_dataset_fail.csv')
+        
         futures_check = {fut.key:fut for fut in self.all_futures[-1]}
         done = [fut for fut in futures_check.values() if fut.done()]
         while futures_check:
             for j, future in enumerate(done):
                 result = self.get_result(future, timeout=5)
-                if not result:
+                if result == (None, None):
                     print('NO RESULT FOUND SKIPPING FOR NOW')
                     continue
+                result, error_info = result
                 
                 self.update_completion_stats(result,len(self.executors)-1)
+                if error_info is not None:
+                    with open(self.run_error_log_path, "a") as f:
+                        f.write(json.dumps(error_info) + "\n")
                 # if self.do_dynamic_scale_down:
                 #     self.dynamic_scale_down(exe_i=len(self.executors)-1, batch_num=batch_num)
                 futures_check.pop(future.key)
                 run_dir = result['run_dir']
                 enchanted_dataset_path = os.path.join(os.path.dirname(run_dir), f'enchanted_dataset_{len(self.executors)-1}.csv')
-                dfi = pd.DataFrame({r:[v] for r,v in result.items()})
-                if os.path.exists(enchanted_dataset_path):
-                    dfi.to_csv(enchanted_dataset_path, mode='a', header=False, index=False)
-                else:
-                    dfi.to_csv(enchanted_dataset_path, mode='w', header=True, index=False)
+                enchanted_dataset_fail_path = os.path.join(os.path.dirname(run_dir), f'enchanted_dataset_fail_{len(self.executors)-1}.csv')
                 
-                if os.path.exists(base_enchanted_dataset_path):
-                    dfi.to_csv(base_enchanted_dataset_path, mode='a', header=False, index=False)
-                else:
-                    dfi.to_csv(base_enchanted_dataset_path, mode='w', header=True, index=False)
-            
+                dfi = pd.DataFrame({r:[v] for r,v in result.items()})
+                if result['success']:
+                    if os.path.exists(enchanted_dataset_path):
+                        dfi.to_csv(enchanted_dataset_path, mode='a', header=False, index=False)
+                    else:
+                        dfi.to_csv(enchanted_dataset_path, mode='w', header=True, index=False)
+                    
+                    if os.path.exists(base_enchanted_dataset_path):
+                        dfi.to_csv(base_enchanted_dataset_path, mode='a', header=False, index=False)
+                    else:
+                        dfi.to_csv(base_enchanted_dataset_path, mode='w', header=True, index=False)
+                elif not result['success']:
+                    if os.path.exists(enchanted_dataset_fail_path):
+                        dfi.to_csv(enchanted_dataset_fail_path, mode='a', header=False, index=False)
+                    else:
+                        dfi.to_csv(enchanted_dataset_fail_path, mode='w', header=True, index=False)
+                    
+                    if os.path.exists(base_enchanted_dataset_fail_path):
+                        dfi.to_csv(base_enchanted_dataset_fail_path, mode='a', header=False, index=False)
+                    else:
+                        dfi.to_csv(base_enchanted_dataset_fail_path, mode='w', header=True, index=False)
                 # this should shut down clusters when they have finished being used. Not to be used when doing active learning
             done = [fut for fut in futures_check.values() if fut.done()]
             
@@ -347,35 +394,40 @@ class DaskNestedExecutor(Executor):
         return done, pending
     
     def get_result(self, future, timeout=60, silent=False):
-        result = None
-        try:
-            result = future.result(timeout=timeout)
-            self.log_stats['fut_res_available'] += 1
-        except:
-            pass
-            
-        if not result:
-            started = time.time()
-            while not result and time.time()-started < timeout:
-                run_dir = self.all_fut_to_rundir.get(future.key)
-                if run_dir:
-                    result_dir = os.path.join(run_dir, 'enchanted_datapoint.csv')
-                    if os.path.exists(result_dir):
-                        try:
-                            df = pd.read_csv(result_dir)
-                            result = df.iloc[0].to_dict()
-                            self.log_stats['fut_res_not_available'] += 1
-                        except pd.errors.EmptyDataError as e:
-                            print('EMPTY DATA ERROR: WAITING LONGER\n',e)
-                    else:
-                        if not silent: print('ENCHANTED DATA POINT FILE DOES NOT EXIST, FUTURE NOT FINISHED:', result_dir)
-                else:
-                    raise RuntimeError(f'THIS FUTURE HAS BEEN SUBMITTED BUT THE RUN_DIR WAS NOT ADDED TO fut_to_rundir, future.key: {future.key}')
-                if not result:
-                    if timeout == 0:
-                        break
-                    if not silent: print('SLEEPING TO SEE IF THE RESULT WILL BECOME AVAILABLE, sec passed:', time.time()-started)
-                    time.sleep(1)
+        started = time.time()
+        result = None, None
+        while result == (None, None) and time.time()-started < timeout:
+            if future.done():
+                try:
+                    result = future.result(timeout=timeout)
+                    self.log_stats['fut_res_available'] += 1
+                except:
+                    pass
+                    
+                if result == (None,None):
+                    while result == (None, None) and time.time()-started < timeout:
+                        run_dir = self.all_fut_to_rundir.get(future.key)
+                        if run_dir:
+                            result_dir = os.path.join(run_dir, 'enchanted_datapoint.csv')
+                            if os.path.exists(result_dir):
+                                try:
+                                    df = pd.read_csv(result_dir)
+                                    result = df.iloc[0].to_dict()
+                                    self.log_stats['fut_res_not_available'] += 1
+                                except pd.errors.EmptyDataError as e:
+                                    print('EMPTY DATA ERROR: WAITING LONGER\n',e)
+                            else:
+                                if not silent: print('ENCHANTED DATA POINT FILE DOES NOT EXIST, FUTURE NOT FINISHED:', result_dir)
+                        else:
+                            raise RuntimeError(f'THIS FUTURE HAS BEEN SUBMITTED BUT THE RUN_DIR WAS NOT ADDED TO fut_to_rundir, future.key: {future.key}')
+                        if result == (None,None):
+                            if timeout == 0:
+                                break
+                            if not silent: print('SLEEPING TO SEE IF THE RESULT WILL BECOME AVAILABLE, sec passed:', time.time()-started)
+                            time.sleep(1)
+            else:
+                print('FUTURE NOT DONE YET, CANNOT GET RESULT NOW, SLEEPING 1 SEC AND TRYING AGAIN')
+                time.sleep(1)
         return result
     
     def update_completion_stats(self, result, exe_i, batch_num=0):

--- a/src/enchanted_surrogates/executors/simulation_task.py
+++ b/src/enchanted_surrogates/executors/simulation_task.py
@@ -2,10 +2,13 @@ import traceback
 from enchanted_surrogates.utils.precise_imports import import_runner
 import os
 import pandas as pd
-
+import uuid
+import sys
+from pprint import pformat
+            
 
 def run_simulation_task(
-        runner_config: dict, run_dir: str, params: dict = None, future=None) -> dict:
+        runner_config: dict, run_dir: str, params: dict = None, future=None, return_errors=False) -> dict:
     """
     Runs a single simulation task using the specified runner and parameters.
     Args:
@@ -17,24 +20,51 @@ def run_simulation_task(
     os.makedirs(run_dir, exist_ok=True)
     runner_type = runner_config['type']
     runner = import_runner(type=runner_type, runner_config=runner_config)
+    error_info = None
     try:
         runner_output: dict = runner.single_code_run(run_dir=run_dir, params=params)
-
+        if 'success' not in runner_output or not isinstance(runner_output.get('success'), bool):
+            raise KeyError(
+                "THE RUNNER'S single_code_run MUST RETURN A DICT THAT ATLEAST CONTAINS THE KEY"
+                + " VALUE PAIR 'success': bool")
+        
     except Exception as exc:
-        print(
-            "=" * 100,
-            f"\nThere was a Python ERROR on when running a simulation task:\n{exc}\n",
-            "params:", params, "\n",
-            "run_dir:", run_dir, "\n",
-            traceback.format_exc(), flush=True)
+        msg = ["=" * 100,
+                f"\nThere was a Python ERROR on when running a simulation task:", str(exc),
+                "params:", str(params),
+                "run_dir:", run_dir,
+                traceback.format_exc()]
         # print the whole traceback and not just the last error
-        runner_output = {"success": False} 
-    if 'success' not in runner_output or not isinstance(runner_output.get('success'), bool):
-        raise KeyError(
-            "THE RUNNER'S single_code_run MUST RETURN A DICT THAT ATLEAST CONTAINS THE KEY"
-            + " VALUE PAIR 'success': bool")
+        error_id = f"error_id_{uuid.uuid1()}"
+        error_info = {
+            "success": False,
+            "error_id": error_id,
+            "exception_type": type(exc).__name__,
+            "exception_message": str(exc),
+            "traceback": traceback.format_exc(),
+            "params": params,
+            "run_dir": run_dir,
+            "python_version": sys.version,
+            "module": exc.__class__.__module__,
+        }
+        runner_output = {"success": False, "error_id": error_id}
+        try:   
+            print('\n'.join(msg), flush=True) # This can return a broken pipe error.
+        except Exception as exc2:
+            home = os.path.expanduser("~")
+            extra_errors_path = os.path.join(home,f'enchanted_extra_{error_id}.txt')            
+            with open(extra_errors_path, "w", encoding="utf-8") as f:
+                f.write(pformat(msg))
+                f.write(pformat(error_info))
+        
     runner_output.update(params)
     runner_output['run_dir'] = run_dir
-    df_point = pd.DataFrame({r:[v] for r,v in runner_output.items()})
-    df_point.to_csv(os.path.join(run_dir, 'enchanted_datapoint.csv'), header=True, index=False)
-    return runner_output
+    
+    if os.path.exists(run_dir):
+        df_point = pd.DataFrame({r:[v] for r,v in runner_output.items()})
+        df_point.to_csv(os.path.join(run_dir, 'enchanted_datapoint.csv'), header=True, index=False)
+    
+    if return_errors:
+        return runner_output, error_info
+    else:
+        return runner_output

--- a/src/enchanted_surrogates/executors/simulation_task.py
+++ b/src/enchanted_surrogates/executors/simulation_task.py
@@ -8,7 +8,7 @@ from pprint import pformat
             
 
 def run_simulation_task(
-        runner_config: dict, run_dir: str, params: dict = None, future=None, return_errors=False) -> dict:
+        runner_config: dict, run_dir: str, params: dict = None, future=None, return_errors=False, rm_run_dir=False) -> dict:
     """
     Runs a single simulation task using the specified runner and parameters.
     Args:
@@ -60,7 +60,7 @@ def run_simulation_task(
     runner_output.update(params)
     runner_output['run_dir'] = run_dir
     
-    if '/tmp/' in run_dir and os.path.exists(run_dir):
+    if rm_run_dir and os.path.exists(run_dir):
         os.system(f'rm -r {run_dir}')
     
     if os.path.exists(run_dir):

--- a/src/enchanted_surrogates/executors/simulation_task.py
+++ b/src/enchanted_surrogates/executors/simulation_task.py
@@ -1,11 +1,10 @@
-import traceback
-from enchanted_surrogates.utils.precise_imports import import_runner
 import os
 import pandas as pd
 import uuid
 import sys
 from pprint import pformat
-            
+import traceback
+from enchanted_surrogates.utils.precise_imports import import_runner        
 
 def run_simulation_task(
         runner_config: dict, run_dir: str, params: dict = None, future=None, return_errors=False, rm_run_dir=False) -> dict:
@@ -62,7 +61,8 @@ def run_simulation_task(
     
     if rm_run_dir and os.path.exists(run_dir):
         os.system(f'rm -r {run_dir}')
-    
+
+    # Create datapoint .csv file in the run directory
     if os.path.exists(run_dir):
         df_point = pd.DataFrame({r:[v] for r,v in runner_output.items()})
         df_point.to_csv(os.path.join(run_dir, 'enchanted_datapoint.csv'), header=True, index=False)

--- a/src/enchanted_surrogates/executors/simulation_task.py
+++ b/src/enchanted_surrogates/executors/simulation_task.py
@@ -60,6 +60,9 @@ def run_simulation_task(
     runner_output.update(params)
     runner_output['run_dir'] = run_dir
     
+    if '/tmp/' in run_dir and os.path.exists(run_dir):
+        os.system(f'rm -r {run_dir}')
+    
     if os.path.exists(run_dir):
         df_point = pd.DataFrame({r:[v] for r,v in runner_output.items()})
         df_point.to_csv(os.path.join(run_dir, 'enchanted_datapoint.csv'), header=True, index=False)

--- a/src/enchanted_surrogates/utils/time_format.py
+++ b/src/enchanted_surrogates/utils/time_format.py
@@ -1,0 +1,9 @@
+from datetime import timedelta
+
+def format_sec(seconds):
+    td = timedelta(seconds=seconds)
+    days = td.days
+    hours, remainder = divmod(td.seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{days}d - {hours:02}:{minutes:02}:{seconds:02}"
+

--- a/tests/automated_tests_no_HPC/test_simple_workflow.py
+++ b/tests/automated_tests_no_HPC/test_simple_workflow.py
@@ -35,7 +35,7 @@ def test_full_workflow_local(tmp_path):
     executor.start_runs()
     # This should create {budget} folders with ??? inside
 
-    assert len(glob.glob(os.path.join(base_run_dir, 'batch_0', "*"))) == budget
+    assert len(glob.glob(os.path.join(base_run_dir, "*"))) == budget
     executor.clean()
 
     # Clean up test
@@ -67,7 +67,7 @@ def test_full_workflow_joblib(tmp_path):
     executor.start_runs()
     # This should create {budget} folders with ??? inside
 
-    created_rundirs = glob.glob(os.path.join(base_run_dir, 'batch_0', "*"))
+    created_rundirs = glob.glob(os.path.join(base_run_dir, "*"))
     assert len(created_rundirs) == budget
     executor.clean()
 

--- a/tests/automated_tests_no_HPC/test_simple_workflow.py
+++ b/tests/automated_tests_no_HPC/test_simple_workflow.py
@@ -35,7 +35,7 @@ def test_full_workflow_local(tmp_path):
     executor.start_runs()
     # This should create {budget} folders with ??? inside
 
-    assert len(glob.glob(os.path.join(base_run_dir, "*"))) == budget
+    assert len(glob.glob(os.path.join(base_run_dir, 'batch_0', "*"))) == budget
     executor.clean()
 
     # Clean up test
@@ -67,7 +67,7 @@ def test_full_workflow_joblib(tmp_path):
     executor.start_runs()
     # This should create {budget} folders with ??? inside
 
-    created_rundirs = glob.glob(os.path.join(base_run_dir, "*"))
+    created_rundirs = glob.glob(os.path.join(base_run_dir, 'batch_0', "*"))
     assert len(created_rundirs) == budget
     executor.clean()
 


### PR DESCRIPTION
When an error happens in single_code_run, run_simulation_task catches it and returnes a different dictionary than if it had succeded. This then messes up the summary file, enchanted_dataset.csv. So I changed the executors to to make two summary files, one for succeded runs and one for failed, so they can have different headders. In run_simulation_task more error info is recorded that wasn't previously and this is optionally returned if the executor requests. Then the executor can make a file with the detailed error information for each failed run, currently this is a json file. There are other small changes, see comments in files changed