### PR TITLE
Bug/load plugins exception handling

### DIFF
--- a/src/enchanted_surrogates/__init__.py
+++ b/src/enchanted_surrogates/__init__.py
@@ -1,13 +1,34 @@
 from importlib.metadata import entry_points
 
+
 def load_plugins():
-    """Load all plugins registered under the 'enchanted_surrogates' entry points."""
-    eps = (list(entry_points(group="enchanted_surrogates.parsers"))
-           + list(entry_points(group="enchanted_surrogates.runners")))
+    """
+    Load all plugins registered under the 'enchanted_surrogates' entry points.
+
+    Returns:
+        dict: {plugin_name: plugin_object} for all successfully loaded plugins.
+    """
+
+    # The entry points defined in the plugins should belong to these groups
+    groups = [
+        "enchanted_surrogates.parsers",
+        "enchanted_surrogates.runners",
+    ]
+
+    # Collect all entry points
+    eps = []
+    for group in groups:
+        eps.extend(entry_points(group=group))
+
+    loaded_plugins = {}
+
+    # Load each plugin and (if successful) store it in the dictionary
     for ep in eps:
         print(f"Loading plugin: {ep.name}")
         try:
-            ep.load()
+            plugin = ep.load()
+            loaded_plugins[ep.name] = plugin
         except Exception as e:
-            print(f"Error loading plugin {ep.name}: {e}")
-    return {ep.name: ep.load() for ep in eps}
+            print(f"Error loading plugin '{ep.name}': {e}")
+
+    return loaded_plugins


### PR DESCRIPTION
The load_plugins() function looped through the plugins and tried to load them twice, and exception handling was only implemented in the first loop. The loop in the return statement failed if the plugin couldn't be loaded. Now, only the successfully loaded plugins are returned. 