### PR TITLE
Feature/enc 123 works for joblib executor

### DIFF
--- a/src/enchanted_surrogates/executors/joblib_executor.py
+++ b/src/enchanted_surrogates/executors/joblib_executor.py
@@ -8,21 +8,17 @@ from enchanted_surrogates.utils.precise_imports import import_sampler
 
 
 class JoblibExecutor(Executor):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.sampler = import_sampler(
-            type=self.sampler_config.pop("type"), sampler_config=self.sampler_config)
+    """
+    Docstring for JoblibExecutor TODO
+    """
 
-    def start_runs(self):
-        while self.sampler.has_budget:
-            samples: list[dict] = self.sampler.get_next_samples()
-            sample_run_dirs = [os.path.join(self.base_run_dir, str(uuid.uuid4())) for _ in samples]
-            new_futures = joblib.Parallel(n_jobs=-1, verbose=10)(
-                joblib.delayed(run_simulation_task)(
-                    self.runner_config, sample_run_dir, params=sample)
-                for sample, sample_run_dir in zip(samples, sample_run_dirs)
-            )
-            self.sampler.register_futures(new_futures)
+    def execute(self, input: list[(str, dict)], sampler):
+        new_futures = joblib.Parallel(n_jobs=-1, verbose=10)(
+            joblib.delayed(run_simulation_task)(
+                self.runner_config, sample_run_dir, params=sample)
+            for sample_run_dir, sample in input
+        )
+        sampler.register_futures(new_futures)
 
     def clean(self):
         print('Joblib runner doesn\'t clean up any resources')

--- a/tests/executors/test_joblib_executor.py
+++ b/tests/executors/test_joblib_executor.py
@@ -4,14 +4,13 @@ from enchanted_surrogates.executors.joblib_executor import JoblibExecutor
 @patch("enchanted_surrogates.executors.joblib_executor.joblib.delayed")
 @patch("enchanted_surrogates.executors.joblib_executor.joblib.Parallel")
 @patch("enchanted_surrogates.executors.joblib_executor.run_simulation_task")
-@patch("enchanted_surrogates.executors.joblib_executor.import_sampler")
-def test_start_runs_registers_futures(mock_import_sampler, mock_run_simulation_task, mock_parallel, mock_delayed, fake_sampler):
-    sampler = fake_sampler([
-        [{"a": 1}, {"b": 2}],
-        [{"a": 3}]
-    ])
+def test_start_runs_registers_futures(mock_run_simulation_task, mock_parallel, mock_delayed):
+    executor_input = [
+        ("test_run_dir_0", {"a": 1, "b": 2}),
+        ("test_run_dir_1", {"c": 2})
+    ]
 
-    mock_import_sampler.return_value = sampler
+    sampler = MagicMock()
     mock_run_simulation_task.return_value = "FUTURE"
 
     # Mocking Parallel and Delayed from joblib so all tasks are actually executed right away
@@ -22,15 +21,12 @@ def test_start_runs_registers_futures(mock_import_sampler, mock_run_simulation_t
 
     executor = JoblibExecutor(
         sampler_config={"type": "mock"},
-        runner_config={"type": "mock_runner"},
-        base_run_dir="/tmp/test_joblib_runs",
+        runner_config={"type": "mock_runner"}
     )
 
-    executor.start_runs()
+    executor.execute(executor_input, sampler)
 
-    assert sampler.has_budget == False
-    # These are called for every list in samples
-    assert sampler.get_next_samples.call_count == 2
-    assert sampler.register_futures.call_count == 2
-    # This for every dict in samples
-    assert mock_run_simulation_task.call_count == 3
+    # Executor should not directly call get next samples
+    assert sampler.get_next_samples.call_count == 0
+    assert sampler.register_futures.call_count == 1
+    assert mock_run_simulation_task.call_count == 2

--- a/tests/executors/test_joblib_executor.py
+++ b/tests/executors/test_joblib_executor.py
@@ -4,7 +4,7 @@ from enchanted_surrogates.executors.joblib_executor import JoblibExecutor
 @patch("enchanted_surrogates.executors.joblib_executor.joblib.delayed")
 @patch("enchanted_surrogates.executors.joblib_executor.joblib.Parallel")
 @patch("enchanted_surrogates.executors.joblib_executor.run_simulation_task")
-def test_start_runs_registers_futures(mock_run_simulation_task, mock_parallel, mock_delayed):
+def test_execute_registers_futures(mock_run_simulation_task, mock_parallel, mock_delayed):
     executor_input = [
         ("test_run_dir_0", {"a": 1, "b": 2}),
         ("test_run_dir_1", {"c": 2})

--- a/tests/executors/test_local_executor.py
+++ b/tests/executors/test_local_executor.py
@@ -2,7 +2,7 @@ from unittest.mock import patch, MagicMock
 from enchanted_surrogates.executors.local_executor import LocalExecutor
 
 @patch("enchanted_surrogates.executors.local_executor.run_simulation_task")
-def test_start_runs_registers_futures(mock_run_simulation_task):
+def test_execute_registers_futures(mock_run_simulation_task):
     executor_input = [
         ("test_run_dir_0", {"a": 1, "b": 2}),
         ("test_run_dir_1", {"c": 2})

--- a/tests/executors/test_local_executor.py
+++ b/tests/executors/test_local_executor.py
@@ -1,28 +1,25 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from enchanted_surrogates.executors.local_executor import LocalExecutor
 
 @patch("enchanted_surrogates.executors.local_executor.run_simulation_task")
-@patch("enchanted_surrogates.executors.local_executor.import_sampler")
-def test_start_runs_registers_futures(mock_import_sampler, mock_run_simulation_task, fake_sampler):
-    sampler = fake_sampler([
-        [{"a": 1}, {"b": 2}],
-        [{"a": 3}]
-    ])
+def test_start_runs_registers_futures(mock_run_simulation_task):
+    executor_input = [
+        ("test_run_dir_0", {"a": 1, "b": 2}),
+        ("test_run_dir_1", {"c": 2})
+    ]
 
     # Fixed return values for the mocked/patched functions
-    mock_import_sampler.return_value = sampler
+    sampler = MagicMock()
     mock_run_simulation_task.return_value = "FUTURE"
 
     executor = LocalExecutor(
         sampler_config={"type": "mock"},
-        runner_config={"type": "mock"},
-        base_run_dir="/tmp/test_runs"
+        runner_config={"type": "mock"}
     )
 
-    executor.start_runs()
+    executor.execute(executor_input, sampler)
 
-    # 2 batches of samples and total 3 samples should result in 3 simulation tasks
-    assert sampler.has_budget == False
-    assert sampler.get_next_samples.call_count == 2
-    assert sampler.register_future.call_count == 3
-    assert mock_run_simulation_task.call_count == 3
+    # Executor should not directly call get next samples
+    assert sampler.get_next_samples.call_count == 0
+    assert sampler.register_future.call_count == 2
+    assert mock_run_simulation_task.call_count == 2


### PR DESCRIPTION
This branch is merged into enc-89-create-a-supervisor-module and fixes sub-issue of supervisor module.

Changes:
- joblib executor refactored to work with the supervisor module
- updated unit tests for joblib executor and local executor