### PR TITLE
Hdf5 storage format

### DIFF
--- a/configs/example_local.yaml
+++ b/configs/example_local.yaml
@@ -10,3 +10,6 @@ runner:
   other_params: {}
 supervisor:
   base_run_dir: "data_dir/local"
+storage:
+  type: hdf5
+  path: "{base_run_dir}/runs.h5"

--- a/configs/example_local.yaml
+++ b/configs/example_local.yaml
@@ -12,4 +12,3 @@ supervisor:
   base_run_dir: "data_dir/local"
 storage:
   type: hdf5
-  path: "{base_run_dir}/runs.h5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "PyYAML",
     "scipy",
     "pyarrow",
+    "h5py",
 ]
 
 [tool.setuptools]

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -10,6 +10,7 @@ import sys
 import warnings
 import shutil
 from time import sleep
+import numpy as np
 import pandas as pd
 from enchanted_surrogates.utils.precise_imports import import_sampler, import_executor
 
@@ -88,11 +89,13 @@ class Supervisor():
         else:
             enchanted_dataset.to_csv(os.path.join(self.base_run_dir, "enchanted_dataset.csv"))
 
+        # Create HDF5 file if configured
+        if self.args.storage and self.args.storage.get('type') != "None":
+            self.create_hdf5(enchanted_dataset)
+
         # Clean run_dirs
         print("Shutting down scheduler and workers...")
         self.executor.clean()
-
-        # TODO: Create HDF5 file
 
     def create_base_run_dir(self, base_run_dir, config_path):
         """
@@ -195,3 +198,69 @@ class Supervisor():
                     enchanted_datapoint = pd.read_csv(datapoint_file)
                     enchanted_dataset = pd.concat([enchanted_dataset, enchanted_datapoint])
         return enchanted_dataset
+    
+    def create_hdf5(self, enchanted_dataset: pd.DataFrame):
+
+        # Check if necessary package is installed
+        try:
+            import h5py
+        except ImportError as e:
+            raise RuntimeError(
+                "HDF5 support requires optional dependency:\n"
+                "h5py"
+            ) from e
+        
+        h5_path = os.path.join(self.base_run_dir, "runs.h5")
+
+        with h5py.File(h5_path, "w") as f:
+            # Aggregated dataset
+            agg_group = f.create_group("data/aggregated")
+
+            values = enchanted_dataset.select_dtypes(include=[np.number]).to_numpy()
+            agg_group.create_dataset(
+                "values",
+                data=values
+            )
+
+            agg_group.create_dataset(
+                "columns",
+                data=np.array(
+                    enchanted_dataset.select_dtypes(include=[np.number]).columns,
+                    dtype=h5py.string_dtype(encoding="utf-8")
+                )
+            )
+
+            # Run directory datasets
+            runs_group = f.create_group("data/runs")
+
+            for name in os.listdir(self.base_run_dir):
+                folder_path = os.path.join(self.base_run_dir, name)
+                csv_path = os.path.join(folder_path, "enchanted_datapoint.csv")
+
+                if not os.path.isfile(csv_path):
+                    continue
+
+                df = pd.read_csv(csv_path)
+                run_group = runs_group.create_group(name)
+
+                # Select only numeric values (also boolean)
+                numeric_df = df.select_dtypes(include=[np.number])
+                
+                run_group.create_dataset(
+                    "values",
+                    data=numeric_df.to_numpy()
+                )
+
+                run_group.create_dataset(
+                    "columns",
+                    data=np.array(
+                        numeric_df.columns,
+                        dtype=h5py.string_dtype("utf-8")
+                    )
+                )
+            
+            # Metadata
+            meta_group = f.create_group("metadata")
+            meta_group.attrs["executor"] = str(self.args.executor.get('type'))
+            meta_group.attrs["sampler"] = str(self.args.sampler.get('type'))
+            meta_group.attrs["runner"] = str(self.args.runner.get('type'))

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -10,6 +10,7 @@ import sys
 import warnings
 import shutil
 from time import sleep
+import h5py
 import numpy as np
 import pandas as pd
 from enchanted_surrogates.utils.precise_imports import import_sampler, import_executor
@@ -198,28 +199,28 @@ class Supervisor():
                     enchanted_datapoint = pd.read_csv(datapoint_file)
                     enchanted_dataset = pd.concat([enchanted_dataset, enchanted_datapoint])
         return enchanted_dataset
-    
-    def create_hdf5(self, enchanted_dataset: pd.DataFrame):
 
-        # Check if necessary package is installed
-        try:
-            import h5py
-        except ImportError as e:
-            raise RuntimeError(
-                "HDF5 support requires optional dependency:\n"
-                "h5py"
-            ) from e
+    def create_hdf5(self, enchanted_dataset: pd.DataFrame):
+        """
+        Creates hdf5 and saves storage file in base_run_dir with name runs.h5
+        Includes aggregated data from enchanted_dataset and run specific data 
+        in structured format. Dataset has only numeric values, column headers
+        are saved separately in in same location. Metadata includes types for
+        sampler, executor and runner.
         
+        Attributes: 
+            - enchanted_dataset (pd.DataFrame): Dataframe containing all run results
+            
+        """
         h5_path = os.path.join(self.base_run_dir, "runs.h5")
 
         with h5py.File(h5_path, "w") as f:
             # Aggregated dataset
             agg_group = f.create_group("data/aggregated")
 
-            values = enchanted_dataset.select_dtypes(include=[np.number]).to_numpy()
             agg_group.create_dataset(
                 "values",
-                data=values
+                data=enchanted_dataset.select_dtypes(include=[np.number]).to_numpy()
             )
 
             agg_group.create_dataset(
@@ -243,9 +244,9 @@ class Supervisor():
                 df = pd.read_csv(csv_path)
                 run_group = runs_group.create_group(name)
 
-                # Select only numeric values (also boolean)
+                # Select only numeric values
                 numeric_df = df.select_dtypes(include=[np.number])
-                
+
                 run_group.create_dataset(
                     "values",
                     data=numeric_df.to_numpy()
@@ -258,7 +259,7 @@ class Supervisor():
                         dtype=h5py.string_dtype("utf-8")
                     )
                 )
-            
+
             # Metadata
             meta_group = f.create_group("metadata")
             meta_group.attrs["executor"] = str(self.args.executor.get('type'))

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -52,11 +52,12 @@ def test_create_hdf5_storage_format(tmp_path, patch_supervisor_imports):
         assert "columns" in group
 
         # Check aggregation dimensions and values
-        agg_values = file["data/aggregated/values"][:]
+        agg_values_shape = file["data/aggregated/values"][:]
+        agg_values_list = file["data/aggregated/values"][:].flatten()
         agg_columns = file["data/aggregated/columns"][:]
 
-        assert agg_values.shape == (3,1)
-        assert agg_values.flatten().tolist() == [0,1,2]
+        assert agg_values_shape.shape == (3,1)
+        assert sorted(agg_values_list.tolist() == [0,1,2])
         assert agg_columns.tolist() == [b"x"]
 
         # Check run dimensions and values

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -56,7 +56,7 @@ def test_create_hdf5_storage_format(tmp_path, patch_supervisor_imports):
         agg_columns = file["data/aggregated/columns"][:]
 
         assert agg_values.shape == (3,1)
-        assert sorted(agg_values.flatten().tolist() == [0,1,2])
+        assert agg_values.flatten().tolist() == [0,1,2]
         assert agg_columns.tolist() == [b"x"]
 
         # Check run dimensions and values

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -52,11 +52,11 @@ def test_create_hdf5_storage_format(tmp_path, patch_supervisor_imports):
         assert "columns" in group
 
         # Check aggregation dimensions and values
-        agg_values = file["data/aggregated/values"][:].flatten()
+        agg_values = file["data/aggregated/values"][:]
         agg_columns = file["data/aggregated/columns"][:]
 
         assert agg_values.shape == (3,1)
-        assert sorted(agg_values.tolist() == [0,1,2])
+        assert sorted(agg_values.flatten().tolist() == [0,1,2])
         assert agg_columns.tolist() == [b"x"]
 
         # Check run dimensions and values

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import h5py
 from enchanted_surrogates.supervisor.supervisor import Supervisor
 from types import SimpleNamespace
 
@@ -17,14 +18,59 @@ def test_create_dataset_combines_csv_files(tmp_path, patch_supervisor_imports):
     patch_supervisor_imports()
     supervisor = Supervisor(make_args(tmp_path))
 
-    for i in range(3):
-        d = tmp_path / f"{i}_0"
-        d.mkdir()
-        pd.DataFrame([{"x": i}]).to_csv(d / "enchanted_datapoint.csv", index=False)
+    create_run_folders(tmp_path, 3)
 
     df = supervisor.create_dataset()
     assert len(df) == 3
     assert set(df["x"]) == {0, 1, 2}
+
+def test_create_hdf5_storage_format(tmp_path, patch_supervisor_imports):
+    patch_supervisor_imports()
+    supervisor = Supervisor(make_args(tmp_path))
+    create_run_folders(tmp_path, 3)
+
+    df = supervisor.create_dataset()
+    supervisor.create_hdf5(df)
+
+    # Check if hdf5 exists
+    output_file = tmp_path / "runs.h5"
+    assert output_file.exists()
+    assert output_file.is_file()
+
+    with h5py.File(output_file, "r") as file:
+
+        
+        # Then, check structure
+        assert "data" in file
+        assert "data/aggregated" in file
+        assert "data/runs" in file
+        assert "metadata" in file
+
+        # Check groups
+        group = file["data/aggregated"]
+        assert "values" in group
+        assert "columns" in group
+
+        # Check aggregation dimensions and values
+        agg_values = file["data/aggregated/values"][:]
+        agg_columns = file["data/aggregated/columns"][:]
+
+        assert agg_values.shape == (3,1)
+        assert agg_values.tolist() == [0,1,2]
+        assert agg_columns.tolist() == [b"x"]
+
+        # Check run dimensions and values
+        run_values = file["data/runs/2_0/values"][:]
+        run_columns = file["data/runs/2_0/values"][:]
+
+        assert run_values.shape == (1,1)
+        assert run_values[0,0] == 2
+        assert run_columns.tolist() == [b"x"]
+
+        # Check that metadata exists
+        meta = file["metadata"].attrs
+        for key in ["executor", "sampler", "runner"]:
+            assert key in meta
 
 def test_start_calls_execute_for_each_sample(tmp_path, patch_supervisor_imports):
     sampler, executor = patch_supervisor_imports([
@@ -49,4 +95,14 @@ def make_args(tmp_path, summary="csv"):
             "base_run_dir": str(tmp_path),
             "summary_datatype": summary,
         },
+        runner={"type": "mock"},
     )
+
+def create_run_folders(tmp_path, amount):
+    """
+    Helper function to create run folders
+    """
+    for i in range(amount):
+        d = tmp_path / f"{i}_0"
+        d.mkdir()
+        pd.DataFrame([{"x":i}]).to_csv(d / "enchanted_datapoint.csv", index=False)

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -52,12 +52,11 @@ def test_create_hdf5_storage_format(tmp_path, patch_supervisor_imports):
         assert "columns" in group
 
         # Check aggregation dimensions and values
-        agg_values_shape = file["data/aggregated/values"][:]
-        agg_values_list = file["data/aggregated/values"][:].flatten()
+        agg_values = file["data/aggregated/values"][:]
         agg_columns = file["data/aggregated/columns"][:]
 
-        assert agg_values_shape.shape == (3,1)
-        assert sorted(agg_values_list.tolist() == [0,1,2])
+        assert agg_values.shape == (3,1)
+        assert sorted(agg_values.flatten().tolist()) == [0,1,2]
         assert agg_columns.tolist() == [b"x"]
 
         # Check run dimensions and values

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -52,11 +52,11 @@ def test_create_hdf5_storage_format(tmp_path, patch_supervisor_imports):
         assert "columns" in group
 
         # Check aggregation dimensions and values
-        agg_values = file["data/aggregated/values"][:]
+        agg_values = file["data/aggregated/values"][:].flatten()
         agg_columns = file["data/aggregated/columns"][:]
 
         assert agg_values.shape == (3,1)
-        assert agg_values.flatten().tolist() == [0,1,2]
+        assert sorted(agg_values.tolist() == [0,1,2])
         assert agg_columns.tolist() == [b"x"]
 
         # Check run dimensions and values
@@ -96,6 +96,7 @@ def make_args(tmp_path, summary="csv"):
             "summary_datatype": summary,
         },
         runner={"type": "mock"},
+        storage={"type": "mock"},
     )
 
 def create_run_folders(tmp_path, amount):

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -61,7 +61,7 @@ def test_create_hdf5_storage_format(tmp_path, patch_supervisor_imports):
 
         # Check run dimensions and values
         run_values = file["data/runs/2_0/values"][:]
-        run_columns = file["data/runs/2_0/values"][:]
+        run_columns = file["data/runs/2_0/columns"][:]
 
         assert run_values.shape == (1,1)
         assert run_values[0,0] == 2

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -1,3 +1,5 @@
+# pylint: disable=E1101
+
 import pandas as pd
 import h5py
 from enchanted_surrogates.supervisor.supervisor import Supervisor
@@ -52,7 +54,7 @@ def test_create_hdf5_storage_format(tmp_path, patch_supervisor_imports):
         assert "columns" in group
 
         # Check aggregation dimensions and values
-        agg_values = file["data/aggregated/values"][:]
+        agg_values = file["data/aggregated/values"][:] 
         agg_columns = file["data/aggregated/columns"][:]
 
         assert agg_values.shape == (3,1)

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -56,7 +56,7 @@ def test_create_hdf5_storage_format(tmp_path, patch_supervisor_imports):
         agg_columns = file["data/aggregated/columns"][:]
 
         assert agg_values.shape == (3,1)
-        assert agg_values.tolist() == [0,1,2]
+        assert agg_values.flatten().tolist() == [0,1,2]
         assert agg_columns.tolist() == [b"x"]
 
         # Check run dimensions and values


### PR DESCRIPTION
_Under construction_

Initial commit. Plan is to have hdf5 storage format configuration in general config file, so user can create the format. Base structure should be offered (to show what could be done) and option for None as well to not have hdf5 at all.

### Current tree created into hdf5:

<img width="415" height="401" alt="Näyttökuva 2026-01-06 kello 5 55 37" src="https://github.com/user-attachments/assets/7d83dbac-18c6-4f5b-a752-60d7442bd190" />


### Things to consider

- Metadata attributes. What should be included? (Software version, git commit, python version)?. Currently just Sampler, Executor and Runner types.
- Chunks. Depends if there is already a planned use case for hdf5 file. In some cases creating chunks fastens the process of reading hdf5 for ML purposes for example
- Sanitaizing datasets. **Currently only numeric values are saved into hdf5**. Some sanitizing should be included for True/False values. String values may not be needed in the database?
- Should this be only optional, or should the h5py package be included in dependencies?

### Todo:

- [ ] Write "How to use" guide and some examples