### PR TITLE
chore: added DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# MacOS specific
+.DS_Store


### PR DESCRIPTION
MacOS creates .DS_store file to folders which have been explored by user. This should be in .gitignore for convenience.