### PR TITLE
test: Running workflow tests from config files

### DIFF
--- a/.github/workflows/pytest_workflow.yml
+++ b/.github/workflows/pytest_workflow.yml
@@ -3,9 +3,9 @@ name: Workflow testing with Pytest
 on: 
   workflow_call:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/pytest_workflow.yml
+++ b/.github/workflows/pytest_workflow.yml
@@ -3,13 +3,10 @@ name: Workflow testing with Pytest
 on: 
   workflow_call:
   push:
-    branches:
-      - main
-      - 'feature/**'
-      - 'bug/**'
-      - 'dev**'
+    branches: [main]
   pull_request:
-    types: [opened, reopened]
+    branches: [main]
+    types: [opened, synchronize, reopened]
 
 jobs:
   pytest:

--- a/.github/workflows/pytest_workflow.yml
+++ b/.github/workflows/pytest_workflow.yml
@@ -1,0 +1,44 @@
+name: Workflow testing with Pytest
+
+on: 
+  workflow_call:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+      - 'bug/**'
+      - 'dev**'
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      # working-directory: enchanted_surrogates
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e . # ← Editable install, required for importlib to do precise imports
+        git submodule init
+        git submodule update
+
+    - name: Running pytest
+      # working-directory: enchanted_surrogates
+      run: |
+        coverage run -m pytest workflow_tests/automated_tests_no_HPC
+
+    - name: Generate Coverage Report  
+      # working-directory: enchanted_surrogates
+      run: |  
+        coverage report -m

--- a/src/enchanted_surrogates/executors/dask_executor.py
+++ b/src/enchanted_surrogates/executors/dask_executor.py
@@ -107,6 +107,7 @@ class DaskExecutor(Executor):
         self.client = None
         self.expected_number_of_workers = None
         self.slurm_job_ids = set()
+        self.is_closed = False
 
     def find_line_in_seff_output(self, lines, entry):
         """
@@ -424,8 +425,12 @@ class DaskExecutor(Executor):
 
         This method is intended to be called when the executor is no longer needed.
         """
+        if self.is_closed:
+            log.debug("Trying to close cluster that has already been closed!")
+            return
 
         self.shutdown_cluster()
+        self.is_closed = True
 
     def shutdown_cluster(self):
         """

--- a/src/enchanted_surrogates/utils/logger.py
+++ b/src/enchanted_surrogates/utils/logger.py
@@ -11,6 +11,9 @@ class Singleton(type):
             cls._instance = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instance
 
+    def reset(cls):
+        cls._instance = None
+
 
 # Stores log level, log_dir etc.
 class LoggerConfig(metaclass=Singleton):

--- a/src/run.py
+++ b/src/run.py
@@ -2,13 +2,10 @@ import os
 import sys
 import yaml
 import argparse
-from datetime import datetime
 from enchanted_surrogates.supervisor.supervisor import Supervisor
-from enchanted_surrogates.utils.precise_imports import import_executor
 from enchanted_surrogates.utils.ascii_art import enchanted_wizard
 from enchanted_surrogates.utils.logger import get_logger, setup_logging, LoggerConfig
 import logging
-import shutil
 
 log = get_logger(__name__)
 
@@ -40,29 +37,20 @@ def load_configuration(config_path: str) -> argparse.Namespace:
     return config
 
 
-def main(arguments: argparse.Namespace, config_path=None):
+def setup_logger(base_run_dir: str, log_level: str):
     """
-    Main function for running the simulation workflow.
+    Prepares the logging module and creates log directory
 
     Args:
-        args (argparse.Namespace): Namespace containing the configuration parameters.
-        config_path (str or None): Optional path for configuration file where
-            configuration is fetched from.
+        base_run_dir (str): The base run directory from supervisor
+        log_level (str): Logging level to use, for example INFO or DEBUG
     """
-
-    supervisor = Supervisor(arguments, config_path=config_path)
-
-    # Setup logging
-    log_dir = os.path.join(supervisor.base_run_dir, "logs")
+    log_dir = os.path.join(base_run_dir, "logs")
     log_file = os.path.join(log_dir, "main.log")
-    log_level = "INFO"
-    if hasattr(arguments, "logging"):
-        log_level = arguments.logging
 
     # Store to logger config
     config = LoggerConfig(log_level=log_level, log_dir=log_dir)
 
-    # Create log dir
     if not os.path.exists(config.log_dir):
         os.makedirs(config.log_dir)
 
@@ -72,6 +60,19 @@ def main(arguments: argparse.Namespace, config_path=None):
         logging.FileHandler(filename=log_file),
     )
 
+
+def main(arguments: argparse.Namespace, config_path=None):
+    """
+    Main function for running the simulation workflow.
+
+    Args:
+        args (argparse.Namespace): Namespace containing the configuration parameters.
+        config_path (str or None): Optional path for configuration file where
+            configuration is fetched from.
+    """
+    supervisor = Supervisor(arguments, config_path=config_path)
+
+    setup_logger(supervisor.base_run_dir, getattr(arguments, "logging", "INFO"))
     log.info("Enchanted surrogates is starting.")
     log.info(f"Base run directory: {supervisor.base_run_dir}")
 

--- a/workflow_tests/automated_tests_no_HPC/conftest.py
+++ b/workflow_tests/automated_tests_no_HPC/conftest.py
@@ -1,16 +1,31 @@
 import pytest
+from pathlib import Path
 from enchanted_surrogates.supervisor.supervisor import Supervisor
+from enchanted_surrogates.utils.logger import LoggerConfig
 from run import load_configuration, setup_logger
 
 @pytest.fixture
-def run_config(config_file: str) -> Supervisor:
+def run_config(tmp_path, request):
     """
-    Helper fixture to run the program with the given config file.
+    Factory fixture to run the program with optional args modifications.
     """
-    args = load_configuration(config_file)
-    supervisor = Supervisor(args, config_path=config_file)
+    def _run(config_file: str, args_override=None):
+        test_dir = Path(request.fspath).parent
+        config_path = (test_dir / config_file).resolve()
 
-    setup_logger(supervisor.base_run_dir, "INFO")
+        args = load_configuration(str(config_path))
+        args.supervisor["base_run_dir"] = tmp_path
 
-    supervisor.start()
-    return supervisor
+        if args_override:
+            for section, values in args_override.items():
+                args.__dict__[section].update(values)
+
+        supervisor = Supervisor(args, config_path=config_path)
+        setup_logger(supervisor.base_run_dir, "INFO")
+        supervisor.start()
+
+        return supervisor
+
+    yield _run
+    # Teardown
+    LoggerConfig.reset()

--- a/workflow_tests/automated_tests_no_HPC/conftest.py
+++ b/workflow_tests/automated_tests_no_HPC/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+from enchanted_surrogates.supervisor.supervisor import Supervisor
+from run import load_configuration, setup_logger
+
+@pytest.fixture
+def run_config(config_file: str) -> Supervisor:
+    """
+    Helper fixture to run the program with the given config file.
+    """
+    args = load_configuration(config_file)
+    supervisor = Supervisor(args, config_path=config_file)
+
+    setup_logger(supervisor.base_run_dir, "INFO")
+
+    supervisor.start()
+    return supervisor

--- a/workflow_tests/automated_tests_no_HPC/test_configs/full_workflow_dask.yaml
+++ b/workflow_tests/automated_tests_no_HPC/test_configs/full_workflow_dask.yaml
@@ -1,0 +1,22 @@
+executors:
+  e1: 
+    type: DaskExecutor
+    LocalCluster_config:
+      name: es-dask_cluster
+      n_workers: 2
+      threads_per_worker: 1
+samplers:
+  s1: 
+    type: RandomSampler
+    bounds: [[-5, 5], [0, 1]]
+    budget: 50
+    parameters: ['c1', 'c2']
+runners:
+  r1: 
+    type: ExampleRunner
+supervisor:
+  base_run_dir: tmp_path
+  run_order:
+  - executor: 'e1'
+    sampler: 's1'
+    runner : 'r1'

--- a/workflow_tests/automated_tests_no_HPC/test_configs/full_workflow_joblib.yaml
+++ b/workflow_tests/automated_tests_no_HPC/test_configs/full_workflow_joblib.yaml
@@ -1,0 +1,18 @@
+executors:
+  e1: 
+    type: JoblibExecutor
+samplers:
+  s1: 
+    type: RandomSampler
+    bounds: [[-5, 5], [0, 1]]
+    budget: 50
+    parameters: ['c1', 'c2']
+runners:
+  r1: 
+    type: ExampleRunner
+supervisor:
+  base_run_dir: tmp_path
+  run_order:
+  - executor: 'e1'
+    sampler: 's1'
+    runner : 'r1'

--- a/workflow_tests/automated_tests_no_HPC/test_configs/full_workflow_local.yaml
+++ b/workflow_tests/automated_tests_no_HPC/test_configs/full_workflow_local.yaml
@@ -1,0 +1,18 @@
+executors:
+  e1: 
+    type: LocalExecutor
+samplers:
+  s1: 
+    type: RandomSampler
+    bounds: [[-5, 5], [0, 1]]
+    budget: 10
+    parameters: ['c1', 'c2']
+runners:
+  r1: 
+    type: ExampleRunner
+supervisor:
+  base_run_dir: tmp_path
+  run_order:
+  - executor: 'e1'
+    sampler: 's1'
+    runner : 'r1'

--- a/workflow_tests/automated_tests_no_HPC/test_configs/nested_dask_executors.yaml
+++ b/workflow_tests/automated_tests_no_HPC/test_configs/nested_dask_executors.yaml
@@ -1,0 +1,41 @@
+executors:
+  e1:
+    type: DaskExecutor
+    LocalCluster_config:
+      name: 'es-dask_cluster'
+      n_workers: 2
+      threads_per_worker: 1
+  e2:
+    type: DaskExecutor
+    LocalCluster_config:
+      name: 'es-dask_cluster'
+      n_workers: 2
+      threads_per_worker: 1
+samplers:
+  s1:
+    type: GridSampler
+    bounds: [[-5, 5], [0, 1]]
+    parameters: ['c1', 'c2']
+    num_samples: 2
+  s2:
+    type: GridSampler
+    bounds: [[-5, 5], [0, 1]]
+    parameters: ['c3', 'c4']
+    num_samples: 2
+runners:
+  r1:
+    type: ExampleRunner
+    parameter_mode: 0
+  r2:
+    type: ExampleRunner
+    parameter_mode: 1
+
+supervisor:
+  base_run_dir: tmp_path
+  run_order:
+  - executor: e1
+    sampler: s1
+    runner: r1
+  - executor: e2
+    sampler: s2
+    runner: r2

--- a/workflow_tests/automated_tests_no_HPC/test_configs/nested_executor_reuse.yaml
+++ b/workflow_tests/automated_tests_no_HPC/test_configs/nested_executor_reuse.yaml
@@ -1,0 +1,46 @@
+executors:
+  e1:
+    type: DaskExecutor
+    LocalCluster_config:
+      name: 'es-dask_cluster'
+      n_workers: 2
+      threads_per_worker: 1
+samplers:
+  s1:
+    type: GridSampler
+    bounds: [[-5, 5], [0, 1]]
+    parameters: ['c1', 'c2']
+    num_samples: 2
+  s2:
+    type: GridSampler
+    bounds: [[-5, 5], [0, 1]]
+    parameters: ['c3', 'c4']
+    num_samples: 2
+  s3:
+    type: GridSampler
+    bounds: [[-5, 5], [0, 1]]
+    parameters: ['c5', 'c6']
+    num_samples: 2
+runners:
+  r1:
+    type: ExampleRunner
+    parameter_mode: 0
+  r2:
+    type: ExampleRunner
+    parameter_mode: 1
+  r3:
+    type: ExampleRunner
+    parameter_mode: 2
+
+supervisor:
+  base_run_dir: tmp_path
+  run_order:
+  - executor: e1
+    sampler: s1
+    runner: r1
+  - executor: e1
+    sampler: s2
+    runner: r2
+  - executor: e1
+    sampler: s3
+    runner: r3

--- a/workflow_tests/automated_tests_no_HPC/test_nested_workflow.py
+++ b/workflow_tests/automated_tests_no_HPC/test_nested_workflow.py
@@ -1,132 +1,31 @@
 """
 Basic tests for the full workflow when using nested executors and samplers.
-Each executor should be tested in a separate function to avoid conflicts."""
-import os
-import glob
-import shutil
-
-from types import SimpleNamespace
+"""
 from enchanted_surrogates.executors import LocalExecutor, JoblibExecutor, DaskExecutor
 from enchanted_surrogates.supervisor.supervisor import Supervisor
+from workflow_tests.utils.test_utils import *
 
-# Configs to be reused in test cases
-dask_config = {
-    'type': 'DaskExecutor',
-    'LocalCluster_config': {
-        'name': 'es-dask_cluster',
-        'n_workers': 2,
-        'threads_per_worker': 1
-    }
-}
-local_config = {
-    'type': 'LocalExecutor'
-}
-sampler_config_1 = {
-    'type': 'GridSampler', 
-    'bounds': [[-5, 5], [0, 1]], 
-    'parameters': ['c1', 'c2'],
-    'num_samples': 2
-}
-sampler_config_2 = {
-    'type': 'GridSampler', 
-    'bounds': [[-5, 5], [0, 1]], 
-    'parameters': ['c3', 'c4'],
-    'num_samples': 2
-}
-sampler_config_3 = {
-    'type': 'GridSampler', 
-    'bounds': [[-5, 5], [0, 1]], 
-    'parameters': ['c5', 'c6'],
-    'num_samples': 2
-}
-runner_config_1 = {
-    'type': 'ExampleRunner',
-    'parameter_mode': 0,
-    'sleep_sec': 0.1
-}
-runner_config_2 = {
-    'type': 'ExampleRunner',
-    'parameter_mode': 1,
-    'sleep_sec': 0.1
-}
-runner_config_3 = {
-    'type': 'ExampleRunner',
-    'parameter_mode': 2,
-    'sleep_sec': 0.1
-}
+def test_nested_dask_executors(tmp_path, run_config):
+    supervisor: Supervisor = run_config("test_configs/nested_dask_executors.yaml")
+    assert len(supervisor.groups) == 2
 
-def test_nested_dask_executors(tmp_path):
-    args = SimpleNamespace(
-        executors = {
-            # New executors are created, but they using the same config
-            'e1': dask_config.copy(),
-            'e2': dask_config.copy()
-        },
-        samplers = {
-            's1': sampler_config_1.copy(),
-            's2': sampler_config_2.copy()
-        },
-        runners = {
-            'r1': runner_config_1.copy(),
-            'r2': runner_config_2.copy()
-        },
-        supervisor = {
-            'base_run_dir': tmp_path,
-            'run_order': [
-                {
-                    'executor': 'e1',
-                    'sampler': 's1',
-                    'runner' : 'r1'
-                },
-                {
-                    'executor': 'e2',
-                    'sampler': 's2',
-                    'runner' : 'r2'
-                }
-            ]
-        }
+    budget_first = supervisor.groups[0].sampler.budget
+    budget_second = supervisor.groups[1].sampler.budget
+    assert get_run_dir_count(tmp_path) == budget_first + budget_first * budget_second
+
+
+def test_nested_dask_executors_with_executor_reuse(tmp_path, run_config):
+    supervisor = run_config("test_configs/nested_executor_reuse.yaml")
+    assert len(supervisor.groups) == 3
+
+    assert supervisor.groups[0].executor == supervisor.groups[1].executor
+    assert supervisor.groups[1].executor == supervisor.groups[2].executor
+
+    budget_first = supervisor.groups[0].sampler.budget
+    budget_second = supervisor.groups[1].sampler.budget
+    budget_third = supervisor.groups[2].sampler.budget
+    assert get_run_dir_count(tmp_path) == (
+        budget_first
+         + budget_first * budget_second
+         + budget_first * budget_second * budget_third
     )
-
-    supervisor = Supervisor(args)
-    supervisor.start()
-
-
-def test_nested_dask_executors_with_executor_reuse(tmp_path):
-    args = SimpleNamespace(
-        executors = {
-            'e1': dask_config.copy()
-        },
-        samplers = {
-            's1': sampler_config_1.copy(),
-            's2': sampler_config_2.copy(),
-            's3': sampler_config_3.copy()
-        },
-        runners = {
-            'r1': runner_config_1.copy(),
-            'r2': runner_config_2.copy(),
-            'r3': runner_config_3.copy()
-        },
-        supervisor = {
-            'base_run_dir': tmp_path,
-            'run_order': [
-                {
-                    'executor': 'e1',
-                    'sampler': 's1',
-                    'runner' : 'r1'
-                },
-                {
-                    'executor': 'e1',
-                    'sampler': 's2',
-                    'runner' : 'r2'
-                },
-                {
-                    'executor': 'e1',
-                    'sampler': 's3',
-                    'runner' : 'r3'
-                }
-            ]
-        }
-    )
-
-    supervisor = Supervisor(args)
-    supervisor.start()

--- a/workflow_tests/automated_tests_no_HPC/test_simple_workflow.py
+++ b/workflow_tests/automated_tests_no_HPC/test_simple_workflow.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from enchanted_surrogates.executors import LocalExecutor, JoblibExecutor, DaskExecutor
 from enchanted_surrogates.supervisor.supervisor import Supervisor
 
+#TODO: parameterize
 
 # https://docs.pytest.org/en/stable/how-to/tmp_path.html
 def test_full_workflow_local(tmp_path):

--- a/workflow_tests/automated_tests_no_HPC/test_simple_workflow.py
+++ b/workflow_tests/automated_tests_no_HPC/test_simple_workflow.py
@@ -5,27 +5,13 @@ Each executor should be tested in a separate function to avoid conflicts."""
 import pytest
 from workflow_tests.utils.test_utils import *
 
-def test_full_workflow_local(tmp_path, run_config):
-    config = "test_configs/full_workflow_local.yaml"
-    supervisor = run_config(config)
-    run_group = supervisor.groups[0]
-
-    # This should create {budget} folders
-    assert get_run_dir_count(tmp_path) == run_group.sampler.budget
-
-
-def test_full_workflow_joblib(tmp_path, run_config):
-    config = "test_configs/full_workflow_joblib.yaml"
-    supervisor = run_config(config)
-    run_group = supervisor.groups[0]
-
-    # This should create {budget} folders
-    assert get_run_dir_count(tmp_path) == run_group.sampler.budget
-
-
-def test_full_workflow_dask(tmp_path, run_config):
-    config = "test_configs/full_workflow_dask.yaml"
-    supervisor = run_config(config)
+@pytest.mark.parametrize("config_file", [
+    "test_configs/full_workflow_local.yaml",
+    "test_configs/full_workflow_joblib.yaml",
+    "test_configs/full_workflow_dask.yaml"
+])
+def test_full_workflow(tmp_path, run_config, config_file):
+    supervisor = run_config(config_file)
     run_group = supervisor.groups[0]
 
     # This should create {budget} folders

--- a/workflow_tests/automated_tests_no_HPC/test_simple_workflow.py
+++ b/workflow_tests/automated_tests_no_HPC/test_simple_workflow.py
@@ -1,159 +1,32 @@
 """
 Basic tests for the full workflow with different executors.
 Each executor should be tested in a separate function to avoid conflicts."""
-import os
-import glob
-import shutil
 
-from types import SimpleNamespace
-from enchanted_surrogates.executors import LocalExecutor, JoblibExecutor, DaskExecutor
-from enchanted_surrogates.supervisor.supervisor import Supervisor
+import pytest
+from workflow_tests.utils.test_utils import *
 
-#TODO: parameterize
+def test_full_workflow_local(tmp_path, run_config):
+    config = "test_configs/full_workflow_local.yaml"
+    supervisor = run_config(config)
+    run_group = supervisor.groups[0]
 
-# https://docs.pytest.org/en/stable/how-to/tmp_path.html
-def test_full_workflow_local(tmp_path):
-    config = {}
-    # -- sampler
-    # TODO: test different samplers
-    bounds = [[-5, 5], [0, 1]]
-    parameters = ['c1', 'c2']
-    budget = 10
-    executor_config = {
-        'type': 'LocalExecutor'
-    }
-    sampler_config = {
-        'type': 'RandomSampler', 'bounds': bounds, 'budget': budget, 'parameters': parameters}
-    runner_config = {
-        'type': 'ExampleRunner'
-    }
-
-    base_run_dir = tmp_path
-
-    args = SimpleNamespace(
-        executors = {
-            'e1': executor_config
-        },
-        samplers = {
-            's1': sampler_config
-        },
-        runners = {
-            'r1': runner_config
-        },
-        supervisor = {
-            'base_run_dir': base_run_dir,
-            'run_order': [
-                {
-                    'executor': 'e1',
-                    'sampler': 's1',
-                    'runner' : 'r1'
-                }
-            ]
-        }
-    )
-
-    supervisor = Supervisor(args)
-    supervisor.start()
-
-    # This should create {budget} folders with ??? inside
-    assert len(next(os.walk(tmp_path))[1]) == budget
+    # This should create {budget} folders
+    assert get_run_dir_count(tmp_path) == run_group.sampler.budget
 
 
-def test_full_workflow_joblib(tmp_path):
-    config = {}
-    # -- sampler
-    # TODO: test different samplers
-    bounds = [[-5, 5], [0, 1]]
-    parameters = ['c1', 'c2']
-    budget = 50
-    executor_config = {
-        'type': 'JoblibExecutor'
-    }
-    sampler_config = {
-        'type': 'RandomSampler', 'bounds': bounds, 'budget': budget, 'parameters': parameters}
-    runner_config = {
-        'type': 'ExampleRunner'
-    }
+def test_full_workflow_joblib(tmp_path, run_config):
+    config = "test_configs/full_workflow_joblib.yaml"
+    supervisor = run_config(config)
+    run_group = supervisor.groups[0]
 
-    base_run_dir = tmp_path
-
-    args = SimpleNamespace(
-        executors = {
-            'e1': executor_config
-        },
-        samplers = {
-            's1': sampler_config
-        },
-        runners = {
-            'r1': runner_config
-        },
-        supervisor = {
-            'base_run_dir': base_run_dir,
-            'run_order': [
-                {
-                    'executor': 'e1',
-                    'sampler': 's1',
-                    'runner' : 'r1'
-                }
-            ]
-        }
-    )
-
-    supervisor = Supervisor(args)
-    supervisor.start()
-    # This should create {budget} folders with ??? inside
-
-    assert len(next(os.walk(tmp_path))[1]) == budget
+    # This should create {budget} folders
+    assert get_run_dir_count(tmp_path) == run_group.sampler.budget
 
 
-def test_full_workflow_dask(tmp_path):
-    config = {}
-    # -- sampler
-    # TODO: test different samplers
-    bounds = [[-5, 5], [0, 1]]
-    parameters = ['c1', 'c2']
-    budget = 50
-    executor_config = {
-        'type': 'DaskExecutor',
-        'LocalCluster_config': {
-            'name': 'es-dask_cluster',
-            'n_workers': 2,
-            'threads_per_worker': 1
-        }
-    }
-    sampler_config = {
-        'type': 'RandomSampler', 'bounds': bounds, 'budget': budget, 'parameters': parameters
-    }
-    runner_config = {
-        'type': 'ExampleRunner'
-    }
+def test_full_workflow_dask(tmp_path, run_config):
+    config = "test_configs/full_workflow_dask.yaml"
+    supervisor = run_config(config)
+    run_group = supervisor.groups[0]
 
-    base_run_dir = tmp_path
-
-    args = SimpleNamespace(
-        executors = {
-            'e1': executor_config
-        },
-        samplers = {
-            's1': sampler_config
-        },
-        runners = {
-            'r1': runner_config
-        },
-        supervisor = {
-            'base_run_dir': base_run_dir,
-            'run_order': [
-                {
-                    'executor': 'e1',
-                    'sampler': 's1',
-                    'runner' : 'r1'
-                }
-            ]
-        }
-    )
-
-    supervisor = Supervisor(args)
-    supervisor.start()
-    # This should create {budget} folders with ??? inside
-
-    assert len(next(os.walk(tmp_path))[1]) == budget
+    # This should create {budget} folders
+    assert get_run_dir_count(tmp_path) == run_group.sampler.budget

--- a/workflow_tests/utils/test_utils.py
+++ b/workflow_tests/utils/test_utils.py
@@ -1,7 +1,22 @@
 import os
+import re
+from pathlib import Path
 from enchanted_surrogates.supervisor.supervisor import Supervisor
 
-def get_run_dir_count(path: str):
-    # TODO filter by folder names
-    return len(next(os.walk(path))[1]) - 1
+def get_run_dir_count(path: str, pattern: str = r"^d\d+_b\d+_r\d+$"):
+    """
+    Get the amount of subdirectories inside the given path that match the pattern filter.
+
+    Arguments:
+    path (str): Path to directory that is looked through.
+    pattern (str): Regex filter pattern. Defaults to d#_b#_r# to find run directories
+    """
+    base = Path(path)
+    regex = re.compile(pattern)
+
+    return sum(
+        1
+        for p in base.iterdir()
+        if p.is_dir() and regex.match(p.name)
+    )
 

--- a/workflow_tests/utils/test_utils.py
+++ b/workflow_tests/utils/test_utils.py
@@ -1,0 +1,7 @@
+import os
+from enchanted_surrogates.supervisor.supervisor import Supervisor
+
+def get_run_dir_count(path: str):
+    # TODO filter by folder names
+    return len(next(os.walk(path))[1]) - 1
+


### PR DESCRIPTION
Workflow tests are now run from test config files instead of being hard coded into the test cases.

## Changes

- Added GitHub Actions workflow to run workflow tests for pull requests and when merged/pushed to main or develop
- Updated automated (no HPC) workflow tests to use test config files, so they are now faster to make and also manual running is now easy
- Fixed issue where logger initialization in `run.py` was causing dask-localslurm tests to fail. Also logger singleton can now be reseted (which is automatically done in every test cleanup)
- Fixed bug where dask cluster shutdown can be called multiple times when reusing them