### PR TITLE
feature: creating default base_run_dir in local use if not configured

### DIFF
--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -73,7 +73,12 @@ class Supervisor:
         self.base_run_dir = args.supervisor.get("base_run_dir")
 
         if self.base_run_dir is None:
-            raise ValueError("base_run_dir is not set in the provided configuration")
+            if sys.stdout.isatty():
+                self.base_run_dir = "base_run_dir"
+                log.warning("No config for base_run_dir was found, " \
+                "created base_run_dir folder to working directory")
+            else:
+                raise ValueError("base_run_dir is not set in the provided configuration")
 
         self.create_base_run_dir(self.base_run_dir, config_path)
 


### PR DESCRIPTION
Creating default base_run_dir for local use if there is not one described in configuration file. 