### PR TITLE
Feature/enc 103 latin hyper cube sampling ported from old code

### DIFF
--- a/configs/example_local.yaml
+++ b/configs/example_local.yaml
@@ -16,7 +16,7 @@ runners:
 
 supervisor:
   base_run_dir: "data_dir/local"
-  local_storage: TMPDIR
+  #local_storage: TMPDIR
   run_mode: "fresh" # "resume" / "extend"
   save_files: "all" # or "custom" or "none"
   save_files_list:

--- a/src/enchanted_surrogates/samplers/latin_hypercube_sampler.py
+++ b/src/enchanted_surrogates/samplers/latin_hypercube_sampler.py
@@ -16,7 +16,7 @@ class LatinHypercubeSampler(Sampler):
     """
     ## Configuration
 
-    To use the `LatinHypercubeSampler`, specify it in the configuration file as in following example:
+    To use the `LatinHypercubeSampler`, specify it in the configuration file like following example:
 
     ```yaml
       samplers:
@@ -41,7 +41,8 @@ class LatinHypercubeSampler(Sampler):
     ## Assumptions and Notes
      - Parameter values are sampled in such way that each parameter bound range is split into 
       n = `batch_size` gaps, and each parameter gets one value from one gap
-     - `LatinHypercubeSampler` generates samples in batches, the batch size is controlled by `batch_size`.
+     - `LatinHypercubeSampler` generates samples in batches, the batch size is controlled by 
+      `batch_size`.
       if `batch_size` is not provided, it defaults to the full sampling `budget`.
      - If the budget is not divisible by `batch_size`, the last batch will have less gaps than other
       batches.

--- a/src/enchanted_surrogates/samplers/latin_hypercube_sampler.py
+++ b/src/enchanted_surrogates/samplers/latin_hypercube_sampler.py
@@ -1,0 +1,119 @@
+"""
+---
+
+## Overview
+
+The latin hypercube sampler creates a hypercube grid of equidistant points that spans
+bounds and num samples.
+
+---
+"""
+import numpy as np
+from enchanted_surrogates.samplers.base_sampler import Sampler
+
+
+class LatinHypercubeSampler(Sampler):
+    """
+    ## Configuration
+
+    To use the `LatinHypercubeSampler`, specify it in the configuration file as in following example:
+
+    ```yaml
+      samplers:
+        s1:
+          type: LatinHypercubeSampler
+          parameters: ['c1', 'c2']
+          bounds: [[1, 10], [0, 1]]
+          budget: 100
+          batch_size: 10 # optional
+
+    ```
+
+    Attributes:
+        self.budget (int): Total number of samples that can be generated.
+        self.bounds (list[tuple[float, float]]): Lower and upper bounds for each parameter.
+        self.parameters (list[str]): Names of the parameters to be sampled.
+        self.batch_size (int): Number of samples returned per batch (defaults to full budget).
+        self.submitted (int): Counter tracking how many samples have been generated so far.
+
+    ---
+
+    ## Assumptions and Notes
+     - Parameter values are sampled in such way that each parameter bound range is split into 
+      n = `batch_size` gaps, and each parameter gets one value from one gap
+     - `LatinHypercubeSampler` generates samples in batches, the batch size is controlled by `batch_size`.
+      if `batch_size` is not provided, it defaults to the full sampling `budget`.
+     - If the budget is not divisible by `batch_size`, the last batch will have less gaps than other
+      batches.
+     - `LatinHypercubeSampler` does not adapt based on previous evaluations
+     - `LatinHypercubeSampler` maintains an internal counter (`self.submitted`) tracking
+      the number of generated samples.
+     - The current implementation assumes continuous parameter spaces (`bounds`).
+
+    ---
+
+    """
+
+    def __init__(self, bounds, budget, parameters, **kwargs):
+        """
+        Initializes the LatinHypercubeSampler.
+
+        Args:
+          bounds (list[tuple[float, float]]): Lower and upper bounds for each parameter.
+          budget (int): Total number of samples that can be generated.
+          parameters (list[str]): Names of the parameters to be sampled. The order must correspond to the order of bounds.
+          batch_size (int, optional): Number of samples returned per call to `get_next_samples`. Defaults to the full sampling budget.
+        """
+        self.budget = budget
+        self.bounds = bounds
+        self.parameters = parameters
+        self.batch_size = kwargs.get("batch_size", self.budget)
+        self.submitted = 0
+
+    def get_next_samples(self) -> list[dict]:
+        """
+        Generates the next batch of parameters according to Latin Hypercube Sampling method.
+        Parameter bounds are divided to `batch_size` amount of gaps, and each parameter gets
+        assigned random value within the gap. 
+
+        Returns:
+           list[dict[str, float]]:
+              A batch of parameter dictionaries, where each dictionary maps
+              parameter names to sampled numeric values.
+        """
+        n = min(self.batch_size, self.budget - self.submitted)
+
+        if n <= 0:
+            return []
+
+        result = np.zeros((n, len(self.parameters)))
+        for dim in range(len(self.parameters)):
+            low, high = self.bounds[dim]
+            cuts = np.linspace(0,1,n+1) # first do cuts in [0,1] and then scale it
+            points = np.random.uniform(cuts[:-1],cuts[1:])
+            np.random.shuffle(points)
+            result[:,dim] = low + points * (high-low) # scale
+
+        list_param_dicts = [
+            {key: result[i, dim] for dim, key in enumerate(self.parameters)}
+            for i in range(n)
+        ]
+
+        self.submitted += len(list_param_dicts)
+        return list_param_dicts
+
+    def register_future(self, future):
+        """
+        Registers a completed or scheduled evaluation.
+
+        This method is part of the sampler interface but is not used by
+        the LatinHypercubeSampler, as sampling does not depend on evaluation results.
+
+        Args:
+          future:
+              A future or handle representing an asynchronous evaluation.
+
+        Returns:
+          None
+        """
+        return None

--- a/tests/samplers/test_latin_hypercube_sampler.py
+++ b/tests/samplers/test_latin_hypercube_sampler.py
@@ -1,0 +1,92 @@
+import numpy as np
+from enchanted_surrogates.samplers.latin_hypercube_sampler import LatinHypercubeSampler
+
+def test_get_next_samples_returns_dicts_within_bounds():
+    bounds = [(0, 1), (10, 20)]
+    params = ["c1", "c2"]
+    sampler = LatinHypercubeSampler(bounds=bounds, budget=10, parameters=params, batch_size=1)
+
+    samples = sampler.get_next_samples()
+
+    assert isinstance(samples, list)
+    assert len(samples) == 1
+    sample = samples[0]
+
+    assert set(sample.keys()) == set(params)
+    assert 0 <= sample["c1"] <= 1
+    assert 10 <= sample["c2"] <= 20
+
+    assert sampler.submitted == 1
+
+def test_batch_size():
+    bounds = [(0, 1), (10, 20)]
+    params = ["c1", "c2"]
+    sampler = LatinHypercubeSampler(bounds=bounds, budget=10, parameters=params, batch_size=5)
+
+    samples = sampler.get_next_samples()
+
+    assert len(samples) == 5
+    assert all(set(s.keys()) == set(params) for s in samples)
+    assert sampler.submitted == 5
+
+
+def test_lhs_covers_all_strata():
+    """Each cut in each dimension has exactly one point"""
+    bounds = [(0, 1), (0, 1)]
+    params = ["c1", "c2"]
+    n = 10
+    sampler = LatinHypercubeSampler(bounds=bounds, budget=n, parameters=params, batch_size=n)
+
+    samples = sampler.get_next_samples()
+
+    for param, (low, high) in zip(params, bounds):
+        values = sorted(s[param] for s in samples)
+        bin_width = (high - low) / n
+        for i, val in enumerate(values):
+            assert low + i * bin_width <= val <= low + (i + 1) * bin_width, (
+                f"{param}: Value {val} does not belong to gap [{low + i*bin_width}, {low + (i+1)*bin_width}]"
+            )
+
+def test_reproducibility_with_fixed_seed():
+    bounds = [(0, 1), (5, 10)]
+    params = ["c1", "c2"]
+    sampler = LatinHypercubeSampler(bounds=bounds, budget=5, parameters=params)
+
+    np.random.seed(42)
+    samples1 = sampler.get_next_samples()
+
+    np.random.seed(42)
+    sampler.submitted = 0
+    samples2 = sampler.get_next_samples()
+
+    assert samples1 == samples2
+
+def test_submitted_counter_accumulates():
+    bounds = [(0, 1)]
+    params = ["c1"]
+    sampler = LatinHypercubeSampler(bounds=bounds, budget=10, parameters=params, batch_size=4)
+
+    sampler.get_next_samples()
+    sampler.get_next_samples()
+
+    assert sampler.submitted == 8
+
+
+def test_default_batch_size_equals_budget():
+    bounds = [(0, 1)]
+    params = ["c1"]
+    sampler = LatinHypercubeSampler(bounds=bounds, budget=7, parameters=params)
+
+    assert sampler.batch_size == 7
+
+def test_last_batch_does_not_exceed_budget():
+    bounds = [(0, 1)]
+    params = ["c1"]
+    sampler = LatinHypercubeSampler(bounds=bounds, budget=10, parameters=params, batch_size=3)
+
+    all_samples = []
+    for _ in range(4):  # last batch should be only one, as budget runs out
+        all_samples += sampler.get_next_samples()
+
+    assert len(all_samples) == 10
+    assert sampler.submitted == 10


### PR DESCRIPTION
Changes to code as now samplers have `budget` and `batch_size` compared to `num_samples` of old code, and other structural changes to accommodate the current state of `Sampler`. 