### PR TITLE
Feature/enc 185 pylint is fairly slow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,10 +3,10 @@
 files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' || true)
 [ -z "$files" ] && exit 0
 # run pylint on staged Python files
-ruff check $files --select E --ignore=PLR,PLC,PLW,E401 --line-length 100
+ruff check $files
 rc=$?
 if [ $rc -ne 0 ]; then
-  echo "Pylint failed; aborting commit."
+  echo "Ruff failed; aborting commit."
   exit $rc
 fi
 exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,7 +3,7 @@
 files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' || true)
 [ -z "$files" ] && exit 0
 # run pylint on staged Python files
-pylint $files --disable=R,C,W,E0401
+ruff check $files --select E --ignore=PLR,PLC,PLW,E401 --line-length 100
 rc=$?
 if [ $rc -ne 0 ]; then
   echo "Pylint failed; aborting commit."

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,4 @@
-name: Pylint
+name: Python linting with ruff
 
 on: 
   workflow_call:
@@ -27,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e . 
-    - name: Analysing the code with pylint
+    - name: Analysing the code with ruff
       # working-directory: enchanted_surrogates
       run: |
-        pylint $(git ls-files '*.py') --disable=R,C,W,E0401
+        ruff check $(git ls-files '*.py') --select E  --ignore=PLR,PLC,PLW,E401 --line-length 100

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -30,4 +30,4 @@ jobs:
     - name: Analysing the code with ruff
       # working-directory: enchanted_surrogates
       run: |
-        ruff check $(git ls-files '*.py') --select E  --ignore=PLR,PLC,PLW,E401 --line-length 100
+        ruff check $(git ls-files '*.py')

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,16 +147,16 @@ The `workflow_tests` folder contains larger workflow tests. These can be run man
 
 
 #### Linting Tests
-A Github Actions workflow is also used for running Pylint tests. These are currently only testing for issues categorized as Errors or Fatal. Message overview [here](https://pylint.pycqa.org/en/latest/user_guide/messages/messages_overview.html).
+A Github Actions workflow is also used for running Ruff tests. These are currently only testing for issues categorized as Errors or Fatal. Message overview [here](https://docs.astral.sh/ruff/rules/). The list of enabled rules can be found in pyproject.toml
 To check the linting locally and get a full overview of all possible issues, run:  
 
 For single file check:  
 
-    pylint /path/to/file.py --disable=R,C,W,E0401
+    ruff /path/to/file.py
 
 For all python files in $PWD:  
 
-    pylint $(find $PWD -name "*.py") --disable=R,C,W,E0401
+    ruff $(find $PWD -name "*.py")
 
 
 #### Machine Specific Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dependencies = [
     "h5py",
 ]
 
+[tool.ruff.lint]
+select = ["F"]
+ignore = ["F401", "F403", "F405"]
+
 [tool.setuptools]
 package-dir = {"" = "src"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
 ]
 
 [tool.ruff.lint]
-select = ["F"]
-ignore = ["F401", "F403", "F405"]
+select = ["PLE", "E"]
+ignore = ["E401", "E501", "E402", "E731", "E711", "E722", "PLE1205"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "dask[complete]",
     "dask-jobqueue",
     "pandas",
-    "pylint",
+    "ruff",
     "coverage",
     "matplotlib",
     "plotly",


### PR DESCRIPTION
Move pylint to ruff. It is way faster and it is really customizable with what rules to include and exclude. I think the review should mainly focus on if the current ruleset makes sense. I tried to edit it to work close to how pylint does it, however it seems to be a bit more strict