### PR TITLE
Feature/enc 181 bug css on automated documentation wont load on 404 pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Enchanted Surrogates
 site_description: Documentation for Enchanted Surrogates
-#site_url: 
+site_url: https://digifusion.github.io/enchanted-surrogates/
 
 theme:
   name: material


### PR DESCRIPTION
This should fix the 404 page not having any CSS on github pages but I don't really know how to try this out. If someone who has the experience with mkdocs can try to build the static page and see if it works as the review. 