### PR TITLE
Feature/enc 168 bug enchanted dataset file is overwritten not appended to

### DIFF
--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -243,12 +243,12 @@ class Supervisor:
             batch (pd.DataFrame): batch to be written
             filename (str): base filename without extension for the written file
         """
-        
+
         csv_path = os.path.join(self.base_run_dir, f"{filename}.csv")
         write_header = not os.path.exists(csv_path)
         batch.to_csv(csv_path, mode="a", header=write_header, index=False)
 
-    
+
     def finalize_summary(self, filename: str = "enchanted_dataset"):
         """
         Finalizes summary after all the batches have been processed. Currently
@@ -285,7 +285,7 @@ class Supervisor:
         csv_path = os.path.join(self.base_run_dir, f"{filename}.csv")
         if os.path.exists(csv_path):
             return pd.read_csv(csv_path)
- 
+
         return pd.DataFrame()
 
     def continue_with_base_run_dir(self, config_path):
@@ -565,8 +565,8 @@ class Supervisor:
             allowed_files = set(default_list)
         else:
             return
-        
-        if base_dir == None:
+
+        if base_dir is None:
             base_dir = self.base_run_dir
 
         for root, dirs, files in os.walk(base_dir, topdown=False):

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -212,7 +212,9 @@ class Supervisor:
             # Create a summary file with last_complete_dataset for nesting
             if depth < len(self.groups) - 1:
                 self.write_summary(
-                    last_complete_dataset, "last_complete_enchanted_dataset"
+                    dataset=last_complete_dataset,
+                    filename="last_complete_enchanted_dataset",
+                    write_mode="w"
                 )
 
             self.fetch_from_local_storage()
@@ -232,21 +234,24 @@ class Supervisor:
         for group in self.groups:
             group.executor.clean()
 
-    def write_summary(self, batch: pd.DataFrame, filename: str = "enchanted_dataset"):
+    def write_summary(self, dataset: pd.DataFrame, filename: str = "enchanted_dataset", write_mode: str = "a"):
         """
         Writes a summary of dataset to base_run_dir/filename
         This functionality is used within the start function to
-        enable seamless sampling. It appends each batch on top of the
-        previous dataset.
+        enable seamless sampling. It appends each dataset on top of the
+        previous dataset by default.
 
         Attributes:
-            batch (pd.DataFrame): batch to be written
+            dataset (pd.DataFrame): batch to be written
             filename (str): base filename without extension for the written file
+            write_mode (str): style of writing summary. appending ("a") is default, write ("w")
+                is used for overwriting summary
         """
 
         csv_path = os.path.join(self.base_run_dir, f"{filename}.csv")
         write_header = not os.path.exists(csv_path)
-        batch.to_csv(csv_path, mode="a", header=write_header, index=False)
+        dataset.to_csv(csv_path, mode=write_mode, header=write_header, index=False)
+
 
 
     def finalize_summary(self, filename: str = "enchanted_dataset"):

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -185,8 +185,11 @@ class Supervisor:
                 self.wait_batch_dirs(run_dirs)
 
                 # Then the files in this batch should be saved into summary files
+                # If nesting, this happens only in the last depth
                 df_batch = self.load_batch_to_df(run_dirs)
                 batch_dataset = pd.concat([batch_dataset, df_batch])
+                if depth == len(self.groups) -1:
+                    self.write_summary(df_batch)
                 group.sampler.register_future(batch_dataset)
 
                 run_data = RunData(
@@ -195,9 +198,6 @@ class Supervisor:
                     submitted_samples=group.sampler.submitted,
                 )
                 run_data.save(self.previous_run_file)
-
-                # Create summary csv or parquet file
-                self.write_summary(batch_dataset)
 
                 self.fetch_from_local_storage()
 
@@ -217,6 +217,9 @@ class Supervisor:
 
             self.fetch_from_local_storage()
 
+        # Convert summary now after batches if configured
+        self.finalize_summary()
+
         # Create HDF5 file by default
         if not hasattr(self.args, "storage") or self.args.storage.get("type") != "None":
             self.create_hdf5(last_complete_dataset)
@@ -229,56 +232,60 @@ class Supervisor:
         for group in self.groups:
             group.executor.clean()
 
-    def write_summary(self, dataset: pd.DataFrame, filename: str = "enchanted_dataset"):
+    def write_summary(self, batch: pd.DataFrame, filename: str = "enchanted_dataset"):
         """
         Writes a summary of dataset to base_run_dir/filename
         This functionality is used within the start function to
-        enable seamless sampling.
+        enable seamless sampling. It appends each batch on top of the
+        previous dataset.
 
         Attributes:
-            dataset (pd.DataFrame): dataset to be written
-            filename (str): filename for the written file
+            batch (pd.DataFrame): batch to be written
+            filename (str): base filename without extension for the written file
         """
+        
+        csv_path = os.path.join(self.base_run_dir, f"{filename}.csv")
+        write_header = not os.path.exists(csv_path)
+        batch.to_csv(csv_path, mode="a", header=write_header, index=False)
+
+    
+    def finalize_summary(self, filename: str = "enchanted_dataset"):
+        """
+        Finalizes summary after all the batches have been processed. Currently
+        creates parquet summary file if configured in the configuration file.
+
+        Attributes:
+            filename (str): base filename without extension for summarized file
+        """
+
         if (
             self.args.supervisor
             and self.args.supervisor.get("summary_datatype") == "parquet"
         ):
-            dataset.to_parquet(
-                os.path.join(self.base_run_dir, f"{filename}.parquet"),
-                engine="pyarrow",
-                index=False,
-            )
-        else:
-            dataset.to_csv(
-                os.path.join(self.base_run_dir, f"{filename}.csv"), index=False
-            )
+            csv_path = os.path.join(self.base_run_dir, f"{filename}.csv")
+            if os.path.exists(csv_path):
+                df = pd.read_csv(csv_path)
+                df.to_parquet(
+                    os.path.join(self.base_run_dir, f"{filename}.parquet"),
+                    engine="pyarrow",
+                    index=False,
+                )
 
     def read_summary(self, filename: str = "enchanted_dataset") -> pd.DataFrame:
         """
         Reads the summary written by write_summary.
 
         Attributes:
-            filename (str): file to be read
+            filename (str): base filename without extension for the file to be read
 
         Returns:
-            pd.Dataframe: read dataset
+            pd.Dataframe: dataset from the disk or an empty DataFrame if not found
         """
-        if (
-            self.args.supervisor
-            and self.args.supervisor.get("summary_datatype") == "parquet"
-        ):
-            file = os.path.join(self.base_run_dir, f"{filename}.parquet")
-            if os.path.exists(file):
-                return pd.read_parquet(
-                    file,
-                    engine="pyarrow",
-                )
-            return pd.DataFrame()
 
-        file = os.path.join(self.base_run_dir, f"{filename}.csv")
-        if os.path.exists(file):
-            return pd.read_csv(os.path.join(self.base_run_dir, f"{filename}.csv"))
-
+        csv_path = os.path.join(self.base_run_dir, f"{filename}.csv")
+        if os.path.exists(csv_path):
+            return pd.read_csv(csv_path)
+ 
         return pd.DataFrame()
 
     def continue_with_base_run_dir(self, config_path):


### PR DESCRIPTION
Now in the start() function loop the `enchanted_dataset.csv` is appended, not overwritten. Parquet is created in the very end. 

I am not sure if with the [issue](https://github.com/DIGIfusion/enchanted-surrogates/issues/201) was meant that there should not be last_completed_dataset in the loop at all, so I left it there as it is quite crucial for there to have seamless sampling for nested runs if I understood it correctly.