### PR TITLE
citation mistake

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -273,7 +273,7 @@ If you use this package in your research, please cite:
 ```bibtex
 @Misc{enchanted-surrogates,
   title =        {Enchanted Surrogates: A flexible framework for surrogate modelling of fusion plasma simulations},
-  author =       {A. Kit, A.M. Bruncrona, D. Jordan, A.E. Järvinen},
+  author =       {Adam Kit and Amanda Bruncrona and Daniel Jordan and Aaro Järvinen and Anna Niemelä},
   howpublished = {Github},
   year =         {2025},
   url =          {https://github.com/DIGIfusion/enchanted-surrogates}


### PR DESCRIPTION
changed the citation to include Anna in the team and also to seperate authors with 'and'. This was how I needed to use it for it to work in my overleaf