### PR TITLE
bug: removing files with save_files not working correctly

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -68,32 +68,34 @@ See [example_nested.yaml](../configs/example_nested.yaml).
 
 ### Multi-runner sequential execution
 
-Alongside nested executing, the supervisor also supports sequential sampling.
-In sequential sampling, the sampler's batches are called once but the samples
-go through multiple runners which pass information to each other. This is 
-useful for active learning use cases. Sequential sampling and nested sampling
-can be used together in the same configuration. 
+Alongside nested executing, the supervisor also supports sequential sampling. In
+sequential sampling, the sampler's batches are called once but the samples go
+through multiple runners which pass information to each other. This is useful
+for active learning use cases. Sequential sampling and nested sampling can be
+used together in the same configuration.
 
 To utilize sequential sampling in configurations, multiple runners need to be
-defined in the config file as a list. The same applies to executors.
-The amount of executors and runners defined in run_order must be equal. If this is not met, an exception
-is thrown. Examples of sequential sampling are provided within the configs directory
-under [example_sequential.yaml](../configs/example.sequential.yaml). 
+defined in the config file as a list. The same applies to executors. The amount
+of executors and runners defined in run_order must be equal. If this is not met,
+an exception is thrown. Examples of sequential sampling are provided within the
+configs directory under
+[example_sequential.yaml](../configs/example.sequential.yaml).
 
 Example of how a run_order can be defined to perform sequential sampling:
+
 ```yaml
 supervisor:
   base_run_dir: "data_dir/sequential_local"
   run_order:
-  - sampler: code1_sampler
-    executor:
-      - code1_executor
-      - code2_executor
-      - code3_executor
-    runner:
-      - code1_runner
-      - code2_runner
-      - code3_runner
+    - sampler: code1_sampler
+      executor:
+        - code1_executor
+        - code2_executor
+        - code3_executor
+      runner:
+        - code1_runner
+        - code2_runner
+        - code3_runner
 ```
 
 ### Resuming/extending previous runs
@@ -191,7 +193,7 @@ It is possible to delete unnecessary files from base_run_dir and keep only
 wanted files. By default all is saved. Option custom saves only described files.
 None does not save any files.
 
-**Note: `enchanted_dataset.csv` and `runs.h5` are saved by default.**
+**Note: `enchanted_dataset.csv`, `runs.h5` and `logs` are always saved.**
 
 ```yaml
 supervisor:

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -185,6 +185,11 @@ class Supervisor:
                 )
                 run_data.save(self.previous_run_file)
 
+                # Appends hdf5 file with new datapoints
+                # The final dataset is written later
+                if not hasattr(self.args, "storage") or self.args.storage.get("type") != "None":
+                    self.hdf5_append_datapoints(run_dirs)
+
                 self.fetch_from_local_storage()
 
                 # Clean unwanted files
@@ -210,7 +215,7 @@ class Supervisor:
 
         # Create HDF5 file by default
         if not hasattr(self.args, "storage") or self.args.storage.get("type") != "None":
-            self.create_hdf5(last_complete_dataset)
+            self.hdf5_write_aggregate_dataset_and_metadata(last_complete_dataset)
 
         # Clean unwanted files
         self.delete_unwanted_files(self.save_files_arg, real_run_dir)
@@ -480,22 +485,60 @@ class Supervisor:
             file = os.path.join(d, "enchanted_datapoint.csv")
             dfs.append(pd.read_csv(file))
         return pd.concat(dfs)
-
-    def create_hdf5(self, enchanted_dataset: pd.DataFrame):
+    
+    def hdf5_append_datapoints(self, new_dirs: list[str]):
         """
-        Creates hdf5 and saves storage file in base_run_dir with name runs.h5
-        Includes aggregated data from enchanted_dataset and run specific data
-        in structured format. Dataset has only numeric values, column headers
-        are saved separately in in same location. Metadata includes types for
-        sampler, executor and runner.
+        Appends new datapoints to the hdf5 storage file. This allows removing
+        the intermediate files and directories after each batch run.
 
-        Attributes:
-            - enchanted_dataset (pd.DataFrame): Dataframe containing all run results
+        Args:
+            new_dirs (list[str]): List of new datapoint directories created
+                during a single batch
 
         """
         h5_path = os.path.join(self.base_run_dir, "runs.h5")
 
-        with h5py.File(h5_path, "w") as f:
+        with h5py.File(h5_path, "a") as f:
+            runs_group = f.require_group("data/runs")
+
+            for dir in new_dirs:
+                csv_path = os.path.join(dir, "enchanted_datapoint.csv")
+
+                if not os.path.isfile(csv_path):
+                    continue
+
+                df = pd.read_csv(csv_path)
+
+                # Get just the final path component of dir 
+                dir_name = os.path.basename(dir)
+
+                run_group = runs_group.create_group(dir_name)
+
+                # Select only numeric values
+                numeric_df = df.select_dtypes(include=[np.number])
+
+                run_group.create_dataset("values", data=numeric_df.to_numpy())
+
+                run_group.create_dataset(
+                    "columns",
+                    data=np.array(numeric_df.columns, dtype=h5py.string_dtype("utf-8")),
+                )
+
+    def hdf5_write_aggregate_dataset_and_metadata(self, enchanted_dataset: pd.DataFrame):
+        """
+        Writes the completed dataset and run metadata to the hdf5 storage file.
+        Dataset has only numeric values, column headers are saved separately 
+        in the same location. Metadata includes types for sampler, executor and
+        runner.
+
+        Args:
+            enchanted_dataset (pd.DataFrame): Dataframe containing all run
+                results
+
+        """
+        h5_path = os.path.join(self.base_run_dir, "runs.h5")
+
+        with h5py.File(h5_path, "a") as f:
             # Aggregated dataset
             agg_group = f.create_group("data/aggregated")
 
@@ -512,29 +555,6 @@ class Supervisor:
                 ),
             )
 
-            # Run directory datasets
-            runs_group = f.create_group("data/runs")
-
-            for name in os.listdir(self.data_dir):
-                folder_path = os.path.join(self.data_dir, name)
-                csv_path = os.path.join(folder_path, "enchanted_datapoint.csv")
-
-                if not os.path.isfile(csv_path):
-                    continue
-
-                df = pd.read_csv(csv_path)
-                run_group = runs_group.create_group(name)
-
-                # Select only numeric values
-                numeric_df = df.select_dtypes(include=[np.number])
-
-                run_group.create_dataset("values", data=numeric_df.to_numpy())
-
-                run_group.create_dataset(
-                    "columns",
-                    data=np.array(numeric_df.columns, dtype=h5py.string_dtype("utf-8")),
-                )
-
             # Metadata
             meta_group = f.create_group("metadata")
             run_groups = meta_group.create_group("run_groups")
@@ -544,6 +564,7 @@ class Supervisor:
                 meta_run_group.attrs["sampler"] = str(
                     run_group.sampler.__class__.__name__
                 )
+
                 meta_run_group.attrs["executors"] = []
                 meta_run_group.attrs["runners"] = []
                 for j in range(len(run_group.executors)):
@@ -555,6 +576,7 @@ class Supervisor:
                         meta_run_group.attrs["runners"],
                         str(run_group.runners[j].get("type")),
                     )
+
 
     def delete_unwanted_files(self, argument: str, base_dir: str | None = None):
         """

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -24,6 +24,8 @@ from enchanted_surrogates.supervisor.nested_imports import (
 
 log = get_logger(__name__)
 
+LOG_DIR = "logs"
+
 
 class Supervisor:
     """
@@ -576,11 +578,19 @@ class Supervisor:
         for root, dirs, files in os.walk(base_dir, topdown=False):
             # Remove files
             for file in files:
+                # Do nothing for log files
+                parent = os.path.basename(os.path.dirname(os.path.join(root, file)))
+                if parent == LOG_DIR:
+                    continue
+
                 if file not in allowed_files:
                     file_path = os.path.join(root, file)
                     os.remove(file_path)
             # Remove dirs
             for dir_ in dirs:
+                # Do nothing for log dir
+                if dir_ == LOG_DIR:
+                    continue
                 dir_path = os.path.join(root, dir_)
                 if not os.listdir(dir_path):
                     os.rmdir(dir_path)

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -512,7 +512,7 @@ class Supervisor:
                 # Get just the final path component of dir 
                 dir_name = os.path.basename(dir)
 
-                run_group = runs_group.create_group(dir_name)
+                run_group = runs_group.require_group(dir_name)
 
                 # Select only numeric values
                 numeric_df = df.select_dtypes(include=[np.number])
@@ -540,7 +540,11 @@ class Supervisor:
 
         with h5py.File(h5_path, "a") as f:
             # Aggregated dataset
-            agg_group = f.create_group("data/aggregated")
+            # Remove old dataset if continuing a previous run
+            if f.get("data/aggregated"):
+                del f["data/aggregated"]
+
+            agg_group = f.require_group("data/aggregated")
 
             agg_group.create_dataset(
                 "values",
@@ -556,6 +560,10 @@ class Supervisor:
             )
 
             # Metadata
+            # Remove old metadata if continuing a previous run
+            if f.get("metadata"):
+                del f["metadata"]
+
             meta_group = f.create_group("metadata")
             run_groups = meta_group.create_group("run_groups")
             for i, run_group in enumerate(self.nested_groups):

--- a/src/run.py
+++ b/src/run.py
@@ -2,7 +2,7 @@ import os
 import sys
 import yaml
 import argparse
-from enchanted_surrogates.supervisor.supervisor import Supervisor
+from enchanted_surrogates.supervisor.supervisor import Supervisor, LOG_DIR
 from enchanted_surrogates.utils.ascii_art import enchanted_wizard_version_7
 from enchanted_surrogates.utils.logger import get_logger, setup_logging, LoggerConfig
 import logging
@@ -45,7 +45,7 @@ def setup_logger(base_run_dir: str, log_level: str):
         base_run_dir (str): The base run directory from supervisor
         log_level (str): Logging level to use, for example INFO or DEBUG
     """
-    log_dir = os.path.join(base_run_dir, "logs")
+    log_dir = os.path.join(base_run_dir, LOG_DIR)
     log_file = os.path.join(log_dir, "main.log")
 
     # Store to logger config

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -38,10 +38,12 @@ def test_create_hdf5_storage_format(tmp_path, patch_supervisor_imports):
     supervisor = Supervisor(make_args(tmp_path))
 
     data_path = tmp_path / "data"
-    create_run_folders(data_path, 3)
+    run_folders = create_run_folders(data_path, 3)
 
     df = supervisor.create_dataset()
-    supervisor.create_hdf5(df)
+
+    supervisor.hdf5_append_datapoints(run_folders)
+    supervisor.hdf5_write_aggregate_dataset_and_metadata(df)
 
     # Check if hdf5 exists
     output_file = tmp_path / "runs.h5"
@@ -190,14 +192,19 @@ def make_args(tmp_path, summary="csv", local_storage=None):
     )
 
 
-def create_run_folders(tmp_path, amount):
+def create_run_folders(tmp_path, amount) -> list[str]:
     """
     Helper function to create run folders
     """
+    folders = []
+
     for i in range(amount):
         d = tmp_path / f"d0_b{i}_s0_r0"
+        folders.append(d)
         d.mkdir()
         pd.DataFrame([{"x": i}]).to_csv(d / "enchanted_datapoint.csv", index=False)
+
+    return folders
 
 
 def create_dummy_files(path):


### PR DESCRIPTION
Currently, when setting config option `save_files` to "none" (or "custom"):
- Supervisor fails to remove the log files (since they are locked by the logging process)
- Creating the hdf5 file fails, since `data` directory is already removed.

This PR fixes these by:
- Ignoring `logs` dir when deleting files (file logging could be made a config option)
- Updating the hdf5 file after each batch run 
