### PR TITLE
feat: Success is recorded for each runner

### DIFF
--- a/src/enchanted_surrogates/executors/simulation_task.py
+++ b/src/enchanted_surrogates/executors/simulation_task.py
@@ -51,16 +51,13 @@ def run_simulation_task(
         else:
             log.debug(f"Conflicting key in runner output and input params: {key}")
 
-    # TODO uudelleenjärjestele seuraavia rivejä että run dir vain suoraa asetetaaan viimeiseksi
-    # TODO miten saadaan luotua runner-kohtaiset output-sarakkeet? Paras varmaan käyttää runnerien nimiä
-    #   mutta näitä ei tallennetta. Ainahan sen voisi lisätä runner dictiin vaikka jollain __name avaimella
-    runner_output["run_dir"] = run_dir
+    # Copy runner-specific success status
     runner_output[f"success_{runner_name}"] = runner_output["success"]
-    df_point = pd.DataFrame({r:[v] for r,v in runner_output.items()})
-    
-    # Reorder columns so run_dir is always the last
-    rd_column = df_point.pop("run_dir")
-    df_point["run_dir"] = rd_column
 
+    # Add correct run_dir always as the right-most column in csv
+    runner_output.pop("run_dir", None)
+    runner_output["run_dir"] = run_dir
+
+    df_point = pd.DataFrame({r:[v] for r,v in runner_output.items()})
     df_point.to_csv(os.path.join(run_dir, 'enchanted_datapoint.csv'), header=True, index=False)
     return runner_output

--- a/src/enchanted_surrogates/executors/simulation_task.py
+++ b/src/enchanted_surrogates/executors/simulation_task.py
@@ -19,7 +19,9 @@ def run_simulation_task(
     Raises:
     """
     os.makedirs(run_dir, exist_ok=True)
+
     runner_type = runner_config["type"]
+    runner_name = runner_config["__runner_name"]
     runner = import_runner(runner_type=runner_type, runner_config=runner_config)
     try:
         runner_output: dict = runner.single_code_run(run_dir=run_dir, params=params)
@@ -49,7 +51,11 @@ def run_simulation_task(
         else:
             log.debug(f"Conflicting key in runner output and input params: {key}")
 
-    runner_output['run_dir'] = run_dir
+    # TODO uudelleenjärjestele seuraavia rivejä että run dir vain suoraa asetetaaan viimeiseksi
+    # TODO miten saadaan luotua runner-kohtaiset output-sarakkeet? Paras varmaan käyttää runnerien nimiä
+    #   mutta näitä ei tallennetta. Ainahan sen voisi lisätä runner dictiin vaikka jollain __name avaimella
+    runner_output["run_dir"] = run_dir
+    runner_output[f"success_{runner_name}"] = runner_output["success"]
     df_point = pd.DataFrame({r:[v] for r,v in runner_output.items()})
     
     # Reorder columns so run_dir is always the last

--- a/src/enchanted_surrogates/runners/sum_runner.py
+++ b/src/enchanted_surrogates/runners/sum_runner.py
@@ -5,8 +5,16 @@ from enchanted_surrogates.utils.logger import get_logger
 log = get_logger(__name__)
 
 class SumRunner(Runner):
+    """
+    TODO
+    """
+
     def __init__(self, params_to_sum: list[str], **kwargs):
+        """
+        TODO docstring
+        """
         self.params_to_sum = params_to_sum
+        self.fail_if = kwargs.get("fail_if", None)
 
     def single_code_run(self, run_dir: str, params: dict = None) -> dict:
         """
@@ -30,11 +38,15 @@ class SumRunner(Runner):
             out_file.write(str(params))
 
         output: float = 0.0
+        success = True
         for key, value in params.items():
             if key in self.params_to_sum:
                 output += value
 
+        if self.fail_if and abs(output - self.fail_if) < 0.25:
+            success = False
+
         return {
             "output": output,
-            "success": True
+            "success": success
         }

--- a/src/enchanted_surrogates/runners/sum_runner.py
+++ b/src/enchanted_surrogates/runners/sum_runner.py
@@ -6,12 +6,26 @@ log = get_logger(__name__)
 
 class SumRunner(Runner):
     """
-    TODO
+    Example runner for sequential (or nested) workflows. Sums parameters together.
+    
+    Allows different way of operation based on parameters given in config files, which makes
+    this useful for workflow testing. In real use, it would make more sense to implement 
+    separate runners for different purposes.
+
+    Example use:
+    - Samples for three parameters, `c1`, `c2` and `c3` are generated
+    - First SumRunner is defined with `params_to_sum: ['c1', 'c2']`
+        - Result of `single_code_run` will be `c1 + c2`
+    - Second SumRunner is defined with `params_to_sum: ['output', 'c3']`
+        - Result of `single_code_run` will be `result_of_first_runner + c3`
     """
 
     def __init__(self, params_to_sum: list[str], **kwargs):
         """
-        TODO docstring
+        Args:
+            params_to_sum (list[str]): List of parameter names
+            fail_if (int, optional): Runner fails if calculated sum equals this value. 
+                None by default
         """
         self.params_to_sum = params_to_sum
         self.fail_if = kwargs.get("fail_if", None)
@@ -19,6 +33,7 @@ class SumRunner(Runner):
     def single_code_run(self, run_dir: str, params: dict = None) -> dict:
         """
         Sums all params together (if they are in the list given to init function).
+        Also writes all the parameters received as input into a text file.
 
         Args:
             run_dir (str): Run directory of this instance
@@ -43,7 +58,8 @@ class SumRunner(Runner):
             if key in self.params_to_sum:
                 output += value
 
-        if self.fail_if and abs(output - self.fail_if) < 0.25:
+        epsilon = 0.25
+        if self.fail_if and abs(output - self.fail_if) < epsilon:
             success = False
 
         return {

--- a/src/enchanted_surrogates/supervisor/nested_imports.py
+++ b/src/enchanted_surrogates/supervisor/nested_imports.py
@@ -125,7 +125,7 @@ def parse_all_run_groups(args) -> list[RunGroup]:
         run_group = RunGroup(
             [executors[e] for e in group_executors],
             samplers[group_sampler],
-            [args.runners[e] for e in group_runners],
+            [{**args.runners[r], "__runner_name": r} for r in group_runners],
         )
 
         try:

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -141,13 +141,7 @@ class Supervisor:
                 samples = group.sampler.get_next_samples()
 
                 # Merge parameter names for nesting. On first depth run, expanded=samples
-                expanded = []
-                if not last_complete_dataset.empty:
-                    for parent in last_complete_dataset.to_dict(orient="records"):
-                        for sample in samples:
-                            expanded.append({**parent, **sample})
-                else:
-                    expanded = samples
+                expanded = self.get_cartesian_product(samples, last_complete_dataset)
 
                 # Run for each sequential runner/executor combination
                 df_batch = pd.DataFrame()
@@ -165,10 +159,11 @@ class Supervisor:
                     # Wait processes of current batch to complete
                     self.wait_batch_dirs(run_dirs)
 
-                    # Then the files in this batch should be saved into summary files
+                    # Load runner output of this batch, used as input for next sequential run
                     df_batch = self.load_batch_to_df(run_dirs)
                     expanded = df_batch.to_dict(orient="records")
 
+                # Save batch results into summary files
                 batch_dataset = pd.concat([batch_dataset, df_batch])
                 if batch_number == 0:
                     self.write_summary(df_batch, write_mode="w")
@@ -280,6 +275,29 @@ class Supervisor:
             return pd.read_csv(csv_path)
 
         return pd.DataFrame()
+    
+    def get_cartesian_product(self, samples: list[dict], last_dataset: pd.DataFrame) -> list[dict]:
+        """
+        Creates cartesian product of the new samples and the previous dataset.
+        Used for nested sampling.
+
+        Arguments:
+            samples (list[dict]): Sample batch from get_next_samples
+            last_dataset (pd.DataFrame): The complete dataset (summary file) from
+                previous nesting level.
+
+        Returns:
+            out (list[dict]): Cartesian product samples x last_dataset. If last_dataset is empty,
+                only the unaltered samples are returned.
+        """
+        if last_dataset.empty:
+            return samples
+
+        expanded = []
+        for parent in last_dataset.to_dict(orient="records"):
+            for sample in samples:
+                expanded.append({**parent, **sample})
+        return expanded
 
     def continue_with_base_run_dir(self, config_path):
         """

--- a/workflow_tests/automated_tests_no_HPC/test_configs/runner_failure.yaml
+++ b/workflow_tests/automated_tests_no_HPC/test_configs/runner_failure.yaml
@@ -1,0 +1,33 @@
+logging: DEBUG
+
+executors:
+  e1:
+    type: LocalExecutor
+samplers:
+  s1:
+    type: ArraySampler
+    bounds: [[1, 2, 1, 3]]
+    parameters: ['c1']
+  s2:
+    type: ArraySampler
+    bounds: [[1, 3, 1]]
+    parameters: ['c2']
+runners:
+  r1:
+    type: SumRunner
+    params_to_sum: [c1]
+    fail_if: 2
+  r2:
+    type: SumRunner
+    params_to_sum: [c1, c2]
+    fail_if: 2
+
+supervisor:
+  base_run_dir: tmp_path
+  run_order:
+  - executor: e1
+    sampler: s1
+    runner: r1
+  - executor: e1
+    sampler: s2
+    runner: r2

--- a/workflow_tests/automated_tests_no_HPC/test_configs/runner_failure_nested.yaml
+++ b/workflow_tests/automated_tests_no_HPC/test_configs/runner_failure_nested.yaml
@@ -1,3 +1,6 @@
+# Nested config that creates 4+12 samples.
+# Runner fails if the sum of samples is 2.
+# So 1+4 failures are expected to be seen.
 logging: DEBUG
 
 executors:

--- a/workflow_tests/automated_tests_no_HPC/test_configs/runner_failure_sequential.yaml
+++ b/workflow_tests/automated_tests_no_HPC/test_configs/runner_failure_sequential.yaml
@@ -1,6 +1,6 @@
-# Nested config that creates 4+(4*3) samples.
+# Nested config that creates 4 samples.
 # Runner fails if the sum of samples is 2.
-# So (1*3)+4 failures are expected to be seen.
+# So 1+2 failures are expected to be seen.
 logging: DEBUG
 
 executors:
@@ -11,10 +11,6 @@ samplers:
     type: ArraySampler
     bounds: [[1, 2, 1, 3]]
     parameters: ['c1']
-  s2:
-    type: ArraySampler
-    bounds: [[1, 3, 1]]
-    parameters: ['c2']
 runners:
   r1:
     type: SumRunner
@@ -22,15 +18,12 @@ runners:
     fail_if: 2
   r2:
     type: SumRunner
-    params_to_sum: [c1, c2]
+    params_to_sum: [c1, output]
     fail_if: 2
 
 supervisor:
   base_run_dir: tmp_path
   run_order:
-  - executor: e1
+  - executor: [e1, e1]
     sampler: s1
-    runner: r1
-  - executor: e1
-    sampler: s2
-    runner: r2
+    runner: [r1, r2]

--- a/workflow_tests/automated_tests_no_HPC/test_configs/runner_failure_simple.yaml
+++ b/workflow_tests/automated_tests_no_HPC/test_configs/runner_failure_simple.yaml
@@ -1,6 +1,6 @@
-# Sequential config that creates 4 samples.
+# Simple config that creates 4 samples.
 # Runner fails if the sum of samples is 2.
-# So 1+2 failures are expected to be seen.
+# So 1 failure is expected to be seen.
 logging: DEBUG
 
 executors:
@@ -16,14 +16,10 @@ runners:
     type: SumRunner
     params_to_sum: [c1]
     fail_if: 2
-  r2:
-    type: SumRunner
-    params_to_sum: [c1, output]
-    fail_if: 2
 
 supervisor:
   base_run_dir: tmp_path
   run_order:
-  - executor: [e1, e1]
+  - executor: e1
     sampler: s1
-    runner: [r1, r2]
+    runner: [r1]

--- a/workflow_tests/automated_tests_no_HPC/test_runner_success.py
+++ b/workflow_tests/automated_tests_no_HPC/test_runner_success.py
@@ -3,6 +3,7 @@ Workflow tests for verifying a success column is shown for each runner in a nest
 or sequential workflow.
 """
 
+import pytest
 from enchanted_surrogates.supervisor.supervisor import Supervisor, RunGroup
 from workflow_tests.utils.test_utils import *
 
@@ -10,33 +11,34 @@ def get_all_runner_names(groups: list[RunGroup]) -> list[str]:
     all_runners = []
     for group in groups:
         for runner in group.runners:
-            all_runners.append(list(runner.keys())[0])
+            all_runners.append(runner["__runner_name"])
     return all_runners
 
-def test_runner_failures_are_seen_in_summary(tmp_path, run_config):
+@pytest.mark.parametrize("data", [
+    {"config": "test_configs/runner_failure_nested.yaml", "sample_count": 4*3, "failures": [1*3, 4]},
+    {"config": "test_configs/runner_failure_sequential.yaml", "sample_count": 4, "failures": [1, 2]}
+])
+def test_runner_failures_are_seen_in_summary(tmp_path, run_config, data):
     """
-    Nested config that creates 4+(4*3) samples.
-    Runner fails if the sum of samples is 2.
-    So (1*3)+4 failures are expected to be seen.
+    - Asserts that the amount of rows in final summary file is *sample_count*
+    - Asserts all rows have a boolean value for 'success'
+    - *failures[n]* are expected to be seen for the nth runner in order of execution.
     """
-    total_sample_count = 4*3
-    failures = [1*3, 4]
+    config_file = data["config"]
+    total_sample_count = data["sample_count"]
+    failures = data["failures"]
 
-    supervisor: Supervisor = run_config("test_configs/runner_failure_nested.yaml")
+    supervisor: Supervisor = run_config(config_file)
 
     all_runners = get_all_runner_names(supervisor.nested_groups)
     assert len(all_runners) == len(failures)
 
-    # TODO assert total rows is 12
-    # TODO assert failures on first runner is 1 * 3
-    # TODO assert failures on second (final) runner is 4
-    # TODO assert all others should say success=True
     summary = read_summary_file(tmp_path)
     assert len(summary) == total_sample_count
 
+    # Verify amount of failures for each runner
     for i, runner in enumerate(all_runners):
-        # last one is just named success with to suffix
-        name: str = f"success_{runner}" if i < len(all_runners) - 1 else "success"
+        name: str = f"success_{runner}"
         success_count = 0
         failure_count = 0
 
@@ -49,3 +51,8 @@ def test_runner_failures_are_seen_in_summary(tmp_path, run_config):
 
         assert failure_count == failures[i]
         assert success_count + failure_count == total_sample_count
+
+    # Verify 'success' matches that of the final runner
+    final_runner = all_runners[-1]
+    for row in summary:
+        assert row["success"] == row[f"success_{final_runner}"]

--- a/workflow_tests/automated_tests_no_HPC/test_runner_success.py
+++ b/workflow_tests/automated_tests_no_HPC/test_runner_success.py
@@ -1,0 +1,51 @@
+"""
+Workflow tests for verifying a success column is shown for each runner in a nested
+or sequential workflow.
+"""
+
+from enchanted_surrogates.supervisor.supervisor import Supervisor, RunGroup
+from workflow_tests.utils.test_utils import *
+
+def get_all_runner_names(groups: list[RunGroup]) -> list[str]:
+    all_runners = []
+    for group in groups:
+        for runner in group.runners:
+            all_runners.append(list(runner.keys())[0])
+    return all_runners
+
+def test_runner_failures_are_seen_in_summary(tmp_path, run_config):
+    """
+    Nested config that creates 4+(4*3) samples.
+    Runner fails if the sum of samples is 2.
+    So (1*3)+4 failures are expected to be seen.
+    """
+    total_sample_count = 4*3
+    failures = [1*3, 4]
+
+    supervisor: Supervisor = run_config("test_configs/runner_failure_nested.yaml")
+
+    all_runners = get_all_runner_names(supervisor.nested_groups)
+    assert len(all_runners) == len(failures)
+
+    # TODO assert total rows is 12
+    # TODO assert failures on first runner is 1 * 3
+    # TODO assert failures on second (final) runner is 4
+    # TODO assert all others should say success=True
+    summary = read_summary_file(tmp_path)
+    assert len(summary) == total_sample_count
+
+    for i, runner in enumerate(all_runners):
+        # last one is just named success with to suffix
+        name: str = f"success_{runner}" if i < len(all_runners) - 1 else "success"
+        success_count = 0
+        failure_count = 0
+
+        for row in summary:
+            assert isinstance(row[name], bool)
+            if row[name]:
+                success_count += 1
+            else:
+                failure_count += 1
+
+        assert failure_count == failures[i]
+        assert success_count + failure_count == total_sample_count

--- a/workflow_tests/automated_tests_no_HPC/test_runner_success.py
+++ b/workflow_tests/automated_tests_no_HPC/test_runner_success.py
@@ -16,7 +16,8 @@ def get_all_runner_names(groups: list[RunGroup]) -> list[str]:
 
 @pytest.mark.parametrize("data", [
     {"config": "test_configs/runner_failure_nested.yaml", "sample_count": 4*3, "failures": [1*3, 4]},
-    {"config": "test_configs/runner_failure_sequential.yaml", "sample_count": 4, "failures": [1, 2]}
+    {"config": "test_configs/runner_failure_sequential.yaml", "sample_count": 4, "failures": [1, 2]},
+    {"config": "test_configs/runner_failure_simple.yaml", "sample_count": 4, "failures": [1]}
 ])
 def test_runner_failures_are_seen_in_summary(tmp_path, run_config, data):
     """


### PR DESCRIPTION
The bug of failure not showing in nested runs came up when implementing #213 and was already fixed there. The underlying reason was that when creating the `enchanted_datapoint.csv` file, runner output is combined with runner input, and both of them contain the key 'success': Previously, input had priority and so overwrote the actual result. It was changed that in the event of conflict, output has priority.

This PR adds workflow tests for verifying the bug does not reoccur later, and adds a separate column for the success of each runner to the summary file.

## Changes

- Implemented workflow/regression tests for runner failures, simple, nested and sequential configs
- Each runner now has their own success column, with key `success_{runner_name}` where the name suffix is the unique name used in `runners` section of the config file.
  - The runners don't know if they are the last runner, which is why this column is created for every runner even in single-runner configs.
- `SumRunner` now has optional failure parameters which is useful for testing. Also updated its docstrings

## Summary file examples

Summary files generated from running `test_runner_success.py`

<details>

<summary>Simple workflow</summary>

|output|success|c1 |success_r1|run_dir|
|------|-------|---|----------|-------|
|1.0   |True   |1  |True      |...\data\d0_b0_s0_r0|
|2.0   |False  |2  |False     |...\data\d0_b0_s1_r0|
|1.0   |True   |1  |True      |...\data\d0_b0_s2_r0|
|3.0   |True   |3  |True      |...\data\d0_b0_s3_r0|

</details>

<details>

<summary>Nested workflow</summary>

|output|success|c1 |success_r1|c2 |success_r2|run_dir|
|------|-------|---|----------|---|----------|---------------------|
|2.0   |False  |1  |True      |1  |False     |...\data\d1_b0_s0_r0 |
|4.0   |True   |1  |True      |3  |True      |...\data\d1_b0_s1_r0 |
|2.0   |False  |1  |True      |1  |False     |...\data\d1_b0_s2_r0 |
|3.0   |True   |2  |False     |1  |True      |...\data\d1_b0_s3_r0 |
|5.0   |True   |2  |False     |3  |True      |...\data\d1_b0_s4_r0 |
|3.0   |True   |2  |False     |1  |True      |...\data\d1_b0_s5_r0 |
|2.0   |False  |1  |True      |1  |False     |...\data\d1_b0_s6_r0 |
|4.0   |True   |1  |True      |3  |True      |...\data\d1_b0_s7_r0 |
|2.0   |False  |1  |True      |1  |False     |...\data\d1_b0_s8_r0 |
|4.0   |True   |3  |True      |1  |True      |...\data\d1_b0_s9_r0 |
|6.0   |True   |3  |True      |3  |True      |...\data\d1_b0_s10_r0|
|4.0   |True   |3  |True      |1  |True      |...\data\d1_b0_s11_r0|

</details>

<details>

<summary>Sequential workflow</summary>

|output|success|c1 |success_r1|success_r2|run_dir|
|------|-------|---|----------|----------|-------|
|2.0   |False  |1  |True      |False     |...\data\d0_b0_s0_r1|
|4.0   |True   |2  |False     |True      |...\data\d0_b0_s1_r1|
|2.0   |False  |1  |True      |False     |...\data\d0_b0_s2_r1|
|6.0   |True   |3  |True      |True      |...\data\d0_b0_s3_r1|

</details>