### PR TITLE
Daniel Stacked PR [2] feature/monitor_runs_log_failures

### DIFF
--- a/src/enchanted_surrogates/executors/dask_executor.py
+++ b/src/enchanted_surrogates/executors/dask_executor.py
@@ -524,12 +524,6 @@ class DaskExecutor(Executor):
                 log.error("Failed to convert result to DataFrame:", e)
                 continue
 
-            log.info(
-                f"[{i}/{total}] Futures Completed ({(i / total) * 100:.1f}%) | "
-                f"[{num_success}/{i}] Futures Succeeded"
-            )
-            log.info("_" * 100)
-
     def submit_batch(
         self,
         run_dir_sample_pairs,

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -158,6 +158,9 @@ class Supervisor:
                     ]
                     executor.execute(list(zip(run_dirs, expanded)), runner)
 
+                    # monitor runs for failures
+                    self.monitor_runs(run_dirs)
+                    
                     # Wait processes of current batch to complete
                     self.wait_batch_dirs(run_dirs)
 
@@ -487,6 +490,39 @@ class Supervisor:
         """
         while not self.batch_dirs_done(run_dirs):
             sleep(1)
+    
+    def monitor_runs(self, run_dirs: list[str]):
+        """
+        Keeps checking all the run_dirs for failures and logs the failures it finds
+        
+        Attributes:
+            run_dirs (list[str]): List of running directories to monitor
+        """
+        
+        run_dirs = set(run_dirs)   # if it isn't already a set
+
+        while run_dirs:
+            for run_dir in list(run_dirs):   # iterate over a snapshot
+                result = self.load_run_result(run_dir)
+                if result is not None:
+                    # remove so it is not rechecked and we are closer to while loop stopping
+                    run_dirs.remove(run_dir)
+                    if not result['success']:
+                        log_message = [f'THE run_dir {run_dir} HAS FAILED. \n RESULT:']
+                        for key, value in result.items():
+                            log_message.append(f'{key}:{value}')
+                        log.error('\n'.join(log_message))
+
+                
+        
+    def load_run_result(self, run_dir):
+        result_path = os.path.join(run_dir, 'enchanted_datapoint.csv')
+        if os.path.exists(result_path):
+            df = pd.read_csv(result_path)
+            row_dict = df.iloc[0].to_dict()
+            return row_dict
+        else:
+            return None
 
     def load_batch_to_df(self, run_dirs: list[str]) -> pd.DataFrame:
         """

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -21,6 +21,7 @@ from enchanted_surrogates.supervisor.nested_imports import (
     parse_all_run_groups,
     import_saved_files_list,
 )
+from enchanted_surrogates.utils.ascii_loading_bar import ascii_loading_bar
 
 log = get_logger(__name__)
 
@@ -505,9 +506,11 @@ class Supervisor:
         total = len(run_dirs)
         completed = 0
         num_successes = 0
+        log.info(f' debug log failures: {self.log_failures}')
         while run_dirs:
             for run_dir in list(run_dirs):   # iterate over a snapshot
                 result = self.load_run_result(run_dir)
+                log.info(f' debug result for {run_dir}: {result}')
                 if result is not None:
                     # remove so it is not rechecked and we are closer to while loop stopping
                     run_dirs.remove(run_dir)
@@ -516,23 +519,46 @@ class Supervisor:
                         num_successes += 1
                     else:
                         if self.log_failures:
-                            log_message = [f'THE run_dir {run_dir} HAS FAILED. \n RESULT:']
-                            for key, value in result.items():
-                                log_message.append(f'{key}:{value}')
-                            log.debug('\n'.join(log_message))
-                    latest_progress_string = self.write_current_progress_string(depth, batch_number, total, completed, num_successes)
+                            details = "\n".join(f"  {k}: {v}" for k, v in result.items())
+                            log_message = f"""\n\n
+                            
+=== FAILURE =========================================
+Run directory: {run_dir}
 
+Result:
+{details}
+======================================================
+
+                            \n""".strip()
+
+                            log.error(log_message)                            
+                    latest_progress_string = self.write_current_progress_string(depth, batch_number, total, completed, num_successes)
+                sleep(0.1)
+        os.makedirs(os.path.dirname(self.all_progress_info_file), exist_ok=True)
         with open(self.all_progress_info_file, 'a') as file:
             file.write(latest_progress_string)
         
     def write_current_progress_string(self, depth, batch_number, total, completed, num_successes):
-        progress_string=f'''
-DEPTH: {depth} | Batch Number {batch_number}
-Total runs in batch: {total} | Completed: {completed} | Successes: {num_successes}
-Progress: {completed*100/total} %
-Current Success Rate: {num_successes*100/completed if completed > 0 else 0} %
-        '''
+        progress_string=f"""
         
+=== PROGRESS REPORT =====================================
+
+Time:            {pd.Timestamp.now()}
+Depth:           {depth}
+Batch:           {batch_number}
+
+Completed:       {completed}/{total}
+Successes:       {num_successes}
+Failures:        {completed-num_successes}
+Success Rate:    {num_successes*100/completed if completed else 0:5.1f}%
+
+{ascii_loading_bar(total, completed)}
+
+==========================================================
+
+"""
+        
+        os.makedirs(os.path.dirname(self.all_progress_info_file), exist_ok=True)
         with open(self.current_progress_info_file, 'w') as file:
             file.write(progress_string)
         

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -52,7 +52,7 @@ class Supervisor:
         self.base_run_dir = args.supervisor.get("base_run_dir")
         self.run_mode = args.supervisor.get("run_mode", "fresh")
         self.save_files_arg = args.supervisor.get("save_files", "all")
-
+        self.log_failures = args.supervisor.get("log_failures", False)
         if self.base_run_dir is None:
             if sys.stdout.isatty():
                 self.base_run_dir = "base_run_dir"
@@ -77,6 +77,8 @@ class Supervisor:
                 )
 
         self.data_dir = os.path.join(self.base_run_dir, "data")
+        self.current_progress_info_file = os.path.join(self.base_run_dir, LOG_DIR, 'current_progress.txt')
+        self.all_progress_info_file = os.path.join(self.base_run_dir, LOG_DIR, 'all_progress.txt')
         self.previous_run_file = os.path.join(self.base_run_dir, "enchanted_run.yaml")
         self.previous_run_data = None
 
@@ -113,7 +115,6 @@ class Supervisor:
         """
 
         log.info("Starting runs...")
-
         if self.local_storage:
             real_run_dir = self.local_storage
         else:
@@ -158,8 +159,9 @@ class Supervisor:
                     ]
                     executor.execute(list(zip(run_dirs, expanded)), runner)
 
-                    # monitor runs for failures
-                    self.monitor_runs(run_dirs)
+                    # monitor runs for failures and update progress file
+                    self.write_current_progress_string(depth, batch_number, len(run_dirs), 0, 0)
+                    self.monitor_runs(run_dirs, depth = depth, batch_number = batch_number)
                     
                     # Wait processes of current batch to complete
                     self.wait_batch_dirs(run_dirs)
@@ -491,7 +493,7 @@ class Supervisor:
         while not self.batch_dirs_done(run_dirs):
             sleep(1)
     
-    def monitor_runs(self, run_dirs: list[str]):
+    def monitor_runs(self, run_dirs: list[str], depth, batch_number):
         """
         Keeps checking all the run_dirs for failures and logs the failures it finds
         
@@ -500,20 +502,42 @@ class Supervisor:
         """
         
         run_dirs = set(run_dirs)   # if it isn't already a set
-
+        total = len(run_dirs)
+        completed = 0
+        num_successes = 0
         while run_dirs:
             for run_dir in list(run_dirs):   # iterate over a snapshot
                 result = self.load_run_result(run_dir)
                 if result is not None:
                     # remove so it is not rechecked and we are closer to while loop stopping
                     run_dirs.remove(run_dir)
-                    if not result['success']:
-                        log_message = [f'THE run_dir {run_dir} HAS FAILED. \n RESULT:']
-                        for key, value in result.items():
-                            log_message.append(f'{key}:{value}')
-                        log.error('\n'.join(log_message))
+                    completed += 1
+                    if result['success']:
+                        num_successes += 1
+                    else:
+                        if self.log_failures:
+                            log_message = [f'THE run_dir {run_dir} HAS FAILED. \n RESULT:']
+                            for key, value in result.items():
+                                log_message.append(f'{key}:{value}')
+                            log.debug('\n'.join(log_message))
+                    latest_progress_string = self.write_current_progress_string(depth, batch_number, total, completed, num_successes)
 
-                
+        with open(self.all_progress_info_file, 'a') as file:
+            file.write(latest_progress_string)
+        
+    def write_current_progress_string(self, depth, batch_number, total, completed, num_successes):
+        progress_string=f'''
+DEPTH: {depth} | Batch Number {batch_number}
+Total runs in batch: {total} | Completed: {completed} | Successes: {num_successes}
+Progress: {completed*100/total} %
+Current Success Rate: {num_successes*100/completed if completed > 0 else 0} %
+        '''
+        
+        with open(self.current_progress_info_file, 'w') as file:
+            file.write(progress_string)
+        
+        return progress_string
+        
         
     def load_run_result(self, run_dir):
         result_path = os.path.join(run_dir, 'enchanted_datapoint.csv')

--- a/src/enchanted_surrogates/utils/ascii_loading_bar.py
+++ b/src/enchanted_surrogates/utils/ascii_loading_bar.py
@@ -1,0 +1,16 @@
+def ascii_loading_bar(total, progress, bar_size=40):
+    """
+    Return a simple ASCII loading bar.
+    total: total amount of work
+    progress: completed amount
+    bar_size: width of the bar in characters
+    """
+    if total <= 0:
+        raise ValueError("total must be positive")
+
+    ratio = max(0.0, min(1.0, progress / total))
+    filled = int(ratio * bar_size)
+    empty = bar_size - filled
+
+    bar = "[" + "#" * filled + "-" * empty + f"] {ratio*100:5.1f}%"
+    return bar


### PR DESCRIPTION
When there are a lot of dask workers, it can be tedious to check all their separate log files for the reasons why the runs are failing.

This is why I added a monitor to check for failed runs and log the failures in the main log file. This allows user to easily see why their runs are failing as they fail.