### PR TITLE
Feature/clean when finished

### DIFF
--- a/docs/supervisor.md
+++ b/docs/supervisor.md
@@ -91,6 +91,15 @@ supervisor:
         - code3_runner
 ```
 
+### Executor cleanup
+
+Each executor is cleaned up (e.g. Dask clusters are shut down) as soon as it is
+no longer needed, rather than waiting until the whole supervisor run finishes.
+An executor is kept open as long as a later runner in the same sequential
+group, or any runner in a later nested depth, still uses it - this includes an
+executor that is reused by name across multiple stages of `run_order`. Any
+executor not cleaned up along the way is cleaned once the whole run finishes.
+
 ### Resuming/extending previous runs
 
 The supervisor supports seamlessly resuming a previous run, in case of crashes

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -173,7 +173,29 @@ class Supervisor:
                     # Load runner output of this batch, used as input for next sequential run
                     df_batch = self.load_batch_to_df(run_dirs)
                     expanded = df_batch.to_dict(orient="records")
+                    
+                    if group.sampler.submitted == group.sampler.budget:
+                        # Executors still needed: later runners in this group and
+                        # any executor used by a future group
+                        future_executors = group.executors[i + 1:] + [
+                            future_executor
+                            for future_group in self.nested_groups[depth + 1:]
+                            for future_executor in future_group.executors
+                        ]
+                        if executor not in future_executors:
+                            executor.clean()
 
+                # Collect executors still needed by future groups so they stay open
+                future_executors = [
+                    executor
+                    for future_group in self.nested_groups[depth + 1:]
+                    for executor in future_group.executors
+                ]
+                # clean up executors that are not needed anymore to free up resources
+                for executor in group.executors:
+                    if executor not in future_executors:
+                        executor.clean()
+                
                 # Save batch results into summary files
                 batch_dataset = pd.concat([batch_dataset, df_batch])
                 if batch_number == 0:

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -192,7 +192,7 @@ class Supervisor:
                     expanded = df_batch.to_dict(orient="records")
                     
                     if group.sampler.submitted == group.sampler.budget:
-                        self._clean_redundant_executors(depth, i, group)
+                        self._clean_redundant_executors(nested_depth, sequential_depth, group)
 
                 # Save batch results into summary files
                 batch_dataset = pd.concat([batch_dataset, df_batch])
@@ -257,7 +257,7 @@ class Supervisor:
             for executor in group.executors:
                 executor.clean()
 
-    def _clean_redundant_executors(self, depth: int, i: int, group: RunGroup):
+    def _clean_redundant_executors(self, nested_depth: int, sequential_depth: int, group: RunGroup):
         """
         Cleans up group.executors[i] if it is not needed by a later runner in
         this group or by any executor used in a later (nested) group. Should
@@ -265,14 +265,14 @@ class Supervisor:
         i.e. on the last batch of the group.
 
         Attributes:
-            depth (int): index of group within self.nested_groups
-            i (int): index of the executor within group.executors
+            nested_depth (int): index of group within self.nested_groups
+            sequential_depth (int): index of the executor within group.executors
             group (RunGroup): the run group currently being processed
         """
-        executor = group.executors[i]
-        future_executors = group.executors[i + 1:] + [
+        executor = group.executors[sequential_depth]
+        future_executors = group.executors[sequential_depth + 1:] + [
             future_executor
-            for future_group in self.nested_groups[depth + 1:]
+            for future_group in self.nested_groups[nested_depth + 1:]
             for future_executor in future_group.executors
         ]
         if executor not in future_executors:

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -182,27 +182,8 @@ class Supervisor:
                     expanded = df_batch.to_dict(orient="records")
                     
                     if group.sampler.submitted == group.sampler.budget:
-                        # Executors still needed: later runners in this group and
-                        # any executor used by a future group
-                        future_executors = group.executors[i + 1:] + [
-                            future_executor
-                            for future_group in self.nested_groups[depth + 1:]
-                            for future_executor in future_group.executors
-                        ]
-                        if executor not in future_executors:
-                            executor.clean()
+                        self._clean_redundant_executors(depth, i, group)
 
-                # Collect executors still needed by future groups so they stay open
-                future_executors = [
-                    executor
-                    for future_group in self.nested_groups[depth + 1:]
-                    for executor in future_group.executors
-                ]
-                # clean up executors that are not needed anymore to free up resources
-                for executor in group.executors:
-                    if executor not in future_executors:
-                        executor.clean()
-                
                 # Save batch results into summary files
                 batch_dataset = pd.concat([batch_dataset, df_batch])
                 if batch_number == 0:
@@ -265,6 +246,27 @@ class Supervisor:
         for group in self.nested_groups:
             for executor in group.executors:
                 executor.clean()
+
+    def _clean_redundant_executors(self, depth: int, i: int, group: RunGroup):
+        """
+        Cleans up group.executors[i] if it is not needed by a later runner in
+        this group or by any executor used in a later (nested) group. Should
+        only be called once the group's sampler has exhausted its budget,
+        i.e. on the last batch of the group.
+
+        Attributes:
+            depth (int): index of group within self.nested_groups
+            i (int): index of the executor within group.executors
+            group (RunGroup): the run group currently being processed
+        """
+        executor = group.executors[i]
+        future_executors = group.executors[i + 1:] + [
+            future_executor
+            for future_group in self.nested_groups[depth + 1:]
+            for future_executor in future_group.executors
+        ]
+        if executor not in future_executors:
+            executor.clean()
 
     def write_summary(
         self,

--- a/tests/supervisor/test_supervisor.py
+++ b/tests/supervisor/test_supervisor.py
@@ -101,6 +101,166 @@ def test_start_calls_execute_for_each_sample(tmp_path, patch_supervisor_imports)
     assert executors[-1].execute.call_count == 2
 
 
+def test_start_cleans_executors_only_when_no_longer_needed(
+    tmp_path, patch_supervisor_imports
+):
+    """
+    Nested + sequential + batched scenario:
+      - depth 0 runs two executors sequentially (a, then b) and has two batches
+      - depth 1 runs a single executor (c) and has one batch
+
+    An executor must never be cleaned while it is still going to be reused
+    (e.g. executor a/b between depth 0's two batches), and every executor
+    must eventually be cleaned once its group's sampler has exhausted its
+    budget.
+    """
+    samplers, executors = patch_supervisor_imports(
+        [
+            [  # depth 0 sampler: two batches
+                [{"a": 1}],
+                [{"a": 2}],
+            ],
+            [  # depth 1 sampler: one batch
+                [{"a": 3}],
+            ],
+        ]
+    )
+
+    args = make_args(tmp_path)
+    args.executors = {
+        "executor_0a": {"type": "mock"},
+        "executor_0b": {"type": "mock"},
+        "executor_1": {"type": "mock"},
+    }
+    args.samplers = {
+        "sampler_0": {"type": "mock"},
+        "sampler_1": {"type": "mock"},
+    }
+    args.runners = {
+        "runner_0a": {"type": "mock"},
+        "runner_0b": {"type": "mock"},
+        "runner_1": {"type": "mock"},
+    }
+    args.supervisor["run_order"] = [
+        {
+            "executor": ["executor_0a", "executor_0b"],
+            "sampler": "sampler_0",
+            "runner": ["runner_0a", "runner_0b"],
+        },
+        {
+            "executor": "executor_1",
+            "sampler": "sampler_1",
+            "runner": "runner_1",
+        },
+    ]
+
+    supervisor = Supervisor(args)
+
+    # `executors` is only populated once Supervisor.__init__ imports them above.
+    exec_a, exec_b, exec_c = executors
+    names = {id(exec_a): "a", id(exec_b): "b", id(exec_c): "c"}
+    events = []
+
+    for executor in executors:
+        name = names[id(executor)]
+        original_execute = executor.execute.side_effect
+
+        def _execute(input, runner_config, _orig=original_execute, _name=name):
+            _orig(input, runner_config)
+            events.append((_name, "execute"))
+
+        executor.execute.side_effect = _execute
+        executor.clean.side_effect = lambda *a, _name=name, **k: events.append(
+            (_name, "clean")
+        )
+
+    supervisor.start()
+
+    def kinds(name):
+        return [kind for n, kind in events if n == name]
+
+    # executor a/b are each used once per depth-0 batch, executor c once overall
+    assert exec_a.execute.call_count == 2
+    assert exec_b.execute.call_count == 2
+    assert exec_c.execute.call_count == 1
+
+    # Every executor is eventually cleaned up.
+    assert exec_a.clean.called
+    assert exec_b.clean.called
+    assert exec_c.clean.called
+
+    # Critically: a/b must not be cleaned in between depth 0's two batches -
+    # both executes must happen before the first clean for that executor.
+    for name in ("a", "b"):
+        executor_kinds = kinds(name)
+        first_clean = executor_kinds.index("clean")
+        assert executor_kinds[:first_clean].count("execute") == 2, (
+            f"executor {name} was cleaned before finishing both of its batches: "
+            f"{executor_kinds}"
+        )
+
+
+def test_start_keeps_executor_shared_across_depths_open(
+    tmp_path, patch_supervisor_imports
+):
+    """
+    If the same executor (by name) is used by both depth 0 and depth 1, it must
+    stay open across the depth boundary - it should only be cleaned once every
+    batch at every depth that uses it has finished, not as soon as depth 0
+    (which happens first) exhausts its own budget.
+    """
+    samplers, executors = patch_supervisor_imports(
+        [
+            [  # depth 0 sampler: two batches
+                [{"a": 1}],
+                [{"a": 2}],
+            ],
+            [  # depth 1 sampler: one batch
+                [{"a": 3}],
+            ],
+        ]
+    )
+
+    args = make_args(tmp_path)
+    args.executors = {"shared": {"type": "mock"}}
+    args.samplers = {
+        "sampler_0": {"type": "mock"},
+        "sampler_1": {"type": "mock"},
+    }
+    args.runners = {
+        "runner_0": {"type": "mock"},
+        "runner_1": {"type": "mock"},
+    }
+    args.supervisor["run_order"] = [
+        {"executor": "shared", "sampler": "sampler_0", "runner": "runner_0"},
+        {"executor": "shared", "sampler": "sampler_1", "runner": "runner_1"},
+    ]
+
+    supervisor = Supervisor(args)
+
+    (shared_executor,) = executors
+    events = []
+    original_execute = shared_executor.execute.side_effect
+
+    def _execute(input, runner_config):
+        original_execute(input, runner_config)
+        events.append("execute")
+
+    shared_executor.execute.side_effect = _execute
+    shared_executor.clean.side_effect = lambda *a, **k: events.append("clean")
+
+    supervisor.start()
+
+    # used once per depth-0 batch (2) plus once for depth 1's single batch
+    assert shared_executor.execute.call_count == 3
+
+    first_clean = events.index("clean")
+    assert events[:first_clean].count("execute") == 3, (
+        "shared executor was cleaned before depth 1 (which still needed it) "
+        f"had run: {events}"
+    )
+
+
 def test_save_files_option_all(tmp_path, patch_supervisor_imports):
     patch_supervisor_imports()
     supervisor = Supervisor(make_args(tmp_path))

--- a/workflow_tests/automated_tests_no_HPC/test_dataset_completeness.py
+++ b/workflow_tests/automated_tests_no_HPC/test_dataset_completeness.py
@@ -5,32 +5,58 @@ successful row, and no data was lost or duplicated while combining the
 per-run enchanted_datapoint.csv files into the summary.
 """
 
+import math
+
 import pytest
-from workflow_tests.utils.test_utils import *
+
+from workflow_tests.utils.test_utils import get_run_dir_count, read_summary_file
 
 
 @pytest.mark.parametrize("config_file", [
-    "test_configs/full_workflow_local.yaml",
-    "test_configs/full_workflow_joblib.yaml",
-    "test_configs/full_workflow_dask.yaml"
+    "test_configs/full_workflow_local.yaml",       # simple: one sampler, one runner
+    "test_configs/full_workflow_joblib.yaml",       # simple: one sampler, one runner
+    "test_configs/full_workflow_dask.yaml",         # simple: one sampler, one runner
+    "test_configs/sequential_local.yaml",           # sequential: one sampler, two runners
+    "test_configs/nested_sequential.yaml",          # nested: two samplers, each with two sequential runners
 ])
 def test_dataset_contains_all_completed_runs(tmp_path, run_config, config_file):
     supervisor = run_config(config_file)
-    run_group = supervisor.nested_groups[0]
-    budget = run_group.sampler.budget
+
+    # The dataset only contains rows for the deepest (final) run group, so
+    # the expected row count is the product of every group's sampler budget.
+    expected_rows = math.prod(
+        group.sampler.budget for group in supervisor.nested_groups
+    )
+
+    # Each runner used anywhere in the workflow writes its own
+    # "success_<runner_name>" column onto every row it touches.
+    expected_success_columns = {
+        f"success_{runner['__runner_name']}"
+        for group in supervisor.nested_groups
+        for runner in group.runners
+    }
 
     rows = read_summary_file(tmp_path)
 
-    # Every submitted sample should have produced exactly one row
-    assert len(rows) == budget
-    assert get_run_dir_count(tmp_path / "data") == budget
+    assert len(rows) == expected_rows
+
+    # Each of a group's sequential runners gets its own run directory, so a
+    # group at depth N creates (product of budgets up to N) * (its runner count) dirs.
+    expected_run_dirs = sum(
+        math.prod(g.sampler.budget for g in supervisor.nested_groups[: depth + 1])
+        * len(group.runners)
+        for depth, group in enumerate(supervisor.nested_groups)
+    )
+    assert get_run_dir_count(tmp_path / "data") == expected_run_dirs
 
     # No run should be missing or duplicated
     run_dirs = [row["run_dir"] for row in rows]
-    assert len(set(run_dirs)) == budget
+    assert len(set(run_dirs)) == expected_rows
 
-    # Every run should have completed successfully with its parameters recorded
+    # Every run should have completed successfully, with no runner failing
+    # and no nan values in the primary numeric output
     for row in rows:
-        assert row["success_r1"] is True
-        assert row["c1"] is not None
-        assert row["c2"] is not None
+        assert row["success"] is True
+        assert not (isinstance(row["output"], float) and math.isnan(row["output"]))
+        for success_column in expected_success_columns:
+            assert row[success_column] is True

--- a/workflow_tests/automated_tests_no_HPC/test_dataset_completeness.py
+++ b/workflow_tests/automated_tests_no_HPC/test_dataset_completeness.py
@@ -1,0 +1,36 @@
+"""
+Tests that verify enchanted_dataset.csv contains the expected, complete data
+after a workflow finishes - i.e. every submitted sample produced exactly one
+successful row, and no data was lost or duplicated while combining the
+per-run enchanted_datapoint.csv files into the summary.
+"""
+
+import pytest
+from workflow_tests.utils.test_utils import *
+
+
+@pytest.mark.parametrize("config_file", [
+    "test_configs/full_workflow_local.yaml",
+    "test_configs/full_workflow_joblib.yaml",
+    "test_configs/full_workflow_dask.yaml"
+])
+def test_dataset_contains_all_completed_runs(tmp_path, run_config, config_file):
+    supervisor = run_config(config_file)
+    run_group = supervisor.nested_groups[0]
+    budget = run_group.sampler.budget
+
+    rows = read_summary_file(tmp_path)
+
+    # Every submitted sample should have produced exactly one row
+    assert len(rows) == budget
+    assert get_run_dir_count(tmp_path / "data") == budget
+
+    # No run should be missing or duplicated
+    run_dirs = [row["run_dir"] for row in rows]
+    assert len(set(run_dirs)) == budget
+
+    # Every run should have completed successfully with its parameters recorded
+    for row in rows:
+        assert row["success_r1"] is True
+        assert row["c1"] is not None
+        assert row["c2"] is not None


### PR DESCRIPTION
In my helena gene workflow the helena resources stay live and redundant the entire time GENE is running. This change will make sure that executors are cleaned when they are not needed for future runs. 