### PR TITLE
Feature/data packers

### DIFF
--- a/src/enchanted_surrogates/packers/__init__.py
+++ b/src/enchanted_surrogates/packers/__init__.py
@@ -1,0 +1,1 @@
+"""Packer implementations for enchanted_surrogates."""

--- a/src/enchanted_surrogates/packers/ascii_bin_to_hdf5_packer.py
+++ b/src/enchanted_surrogates/packers/ascii_bin_to_hdf5_packer.py
@@ -1,0 +1,226 @@
+import os
+
+import h5py
+import numpy as np
+
+from .base_packer import Packer
+
+from enchanted_surrogates.utils.logger import get_logger
+log = get_logger(__name__)
+
+def _is_binary_file(path: str, chunk_size: int = 8192) -> bool:
+    """
+    Heuristically decide whether a file is binary or ascii text.
+
+    Reads the first `chunk_size` bytes of `path` and treats the file as
+    binary if it contains a null byte or the chunk cannot be decoded as
+    utf-8.
+
+    Args:
+        path (str): Path to the file to inspect.
+        chunk_size (int, optional): Number of bytes read from the start of
+            the file to make the decision. Defaults to 8192.
+
+    Returns:
+        bool: True if the file looks binary, False if it looks like ascii
+        text.
+    """
+    with open(path, 'rb') as f:
+        chunk = f.read(chunk_size)
+    if b'\x00' in chunk:
+        return True
+    try:
+        chunk.decode('utf-8')
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+def _default_hdf5_path() -> str:
+    """
+    Build the default hdf5 output path in the user's home directory.
+
+    The default file is `~/enchanted_data_packed.h5`. If that file already
+    exists, `~/enchanted_data_packed_1.h5`, `_2.h5`, etc. are tried in turn
+    until a path that does not yet exist is found.
+
+    Returns:
+        str: Path to the first available default hdf5 file.
+    """
+    home = os.path.expanduser('~')
+    base_name = 'enchanted_data_packed'
+    path = os.path.join(home, f'{base_name}.h5')
+    if not os.path.exists(path):
+        return path
+
+    n = 1
+    while True:
+        path = os.path.join(home, f'{base_name}_{n}.h5')
+        if not os.path.exists(path):
+            return path
+        n += 1
+
+
+class AsciiBinToHdf5Packer(Packer):
+    """
+    Packer that archives a run directory's raw ascii and binary files into a
+    single hdf5 file, preserving the run directory's tree structure, and can
+    unpack a previously archived run back out to disk.
+
+    All files under a run directory are assumed to be either ascii text or
+    binary; each file is stored as-is (as text or as a raw byte array) rather
+    than being parsed, so unpacking reproduces the original files exactly.
+
+    Every run is stored under its own group named after the run directory's
+    final path component, so `pack_run_dir` can be called repeatedly with
+    different run directories and each is added alongside the previous ones
+    in the same hdf5 file rather than overwriting it.
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Args:
+            hdf5_path (str, optional): Path to the hdf5 file to pack into /
+                unpack from. If not given, defaults to the first available
+                path from `_default_hdf5_path` (`~/enchanted_data_packed.h5`,
+                falling back to `_1.h5`, `_2.h5`, etc. if it already exists).
+        """
+        super().__init__(**kwargs)
+        self.hdf5_path = kwargs.get('hdf5_path') or _default_hdf5_path()
+
+    def pack_run_dir(self, run_dir: str, results: dict = None) -> None:
+        """
+        Pack all files under `run_dir` into this packer's hdf5 file.
+
+        Walks `run_dir` recursively and stores each file as a dataset under
+        `runs/<run_name>/...` in the hdf5 file, mirroring `run_dir`'s
+        subdirectory structure as nested hdf5 groups. Each file is stored
+        either as utf-8 text or as a raw `uint8` byte array, based on
+        whether it is detected as ascii or binary (see `_is_binary_file`).
+        If a run with the same name was already packed, it is deleted and
+        replaced.
+
+        Errors (per file, or packing `run_dir` as a whole) are caught and
+        logged rather than raised, so a single bad run does not interrupt a
+        larger batch of calls.
+
+        Args:
+            run_dir (str): Path to the run directory to pack. Only its final
+                path component (e.g. "run_001") is used as the run's name in
+                the hdf5 file.
+            results (dict, optional): Results previously parsed from
+                `run_dir` by some other parser. Accepted for interface
+                compatibility with `Packer.pack_run_dir`, but ignored - this
+                packer only archives raw files and has no use for parsed
+                values.
+
+        Returns:
+            None
+        """
+        run_dir = os.path.abspath(run_dir)
+        run_name = os.path.basename(os.path.normpath(run_dir))
+
+        try:
+            with h5py.File(self.hdf5_path, 'a') as f:
+                runs_group = f.require_group('runs')
+
+                if run_name in runs_group:
+                    log.warning(
+                        "Run '%s' already exists in %s, overwriting", run_name, self.hdf5_path
+                    )
+                    del runs_group[run_name]
+                run_group = runs_group.create_group(run_name)
+                run_group.attrs['source_dir'] = run_dir
+
+                for dirpath, _, filenames in os.walk(run_dir):
+                    rel_dir = os.path.relpath(dirpath, run_dir)
+                    group = (
+                        run_group
+                        if rel_dir == '.'
+                        else run_group.require_group(rel_dir.replace(os.sep, '/'))
+                    )
+
+                    for filename in sorted(filenames):
+                        file_path = os.path.join(dirpath, filename)
+
+                        try:
+                            if _is_binary_file(file_path):
+                                data = np.fromfile(file_path, dtype=np.uint8)
+                                dataset = group.create_dataset(filename, data=data)
+                                dataset.attrs['file_type'] = 'binary'
+                            else:
+                                with open(file_path, 'r') as fh:
+                                    text = fh.read()
+                                dataset = group.create_dataset(
+                                    filename, data=text, dtype=h5py.string_dtype(encoding='utf-8')
+                                )
+                                dataset.attrs['file_type'] = 'ascii'
+                        except Exception:
+                            log.error("Failed to pack file '%s'", file_path, exc_info=True)
+        except Exception:
+            log.error("Failed to pack run dir '%s' into %s", run_dir, self.hdf5_path, exc_info=True)
+
+    def unpack_run_dir(self, run_dir: str, dest_dir: str) -> str:
+        """
+        Unpack a previously packed run back out to disk under `dest_dir`.
+
+        Args:
+            run_dir (str): Name of the run to unpack, as it was packed. Only
+                the final path component is used, so either the run's
+                original full path (e.g. "/path/to/run_001") or just its
+                name (e.g. "run_001") work equally well.
+            dest_dir (str): Directory to unpack the run into. The run is
+                written to `dest_dir/<run_name>/`, reproducing the original
+                subdirectory structure and file contents.
+
+        Returns:
+            str: Path to the unpacked run directory (`dest_dir/<run_name>`).
+
+        Raises:
+            KeyError: If no run named `run_name` exists in this packer's
+                hdf5 file.
+        """
+        run_name = os.path.basename(os.path.normpath(run_dir))
+        out_dir = os.path.join(dest_dir, run_name)
+
+        with h5py.File(self.hdf5_path, 'r') as f:
+            runs_group = f.get('runs')
+            if runs_group is None or run_name not in runs_group:
+                log.error("Run '%s' not found in %s", run_name, self.hdf5_path)
+                raise KeyError(f"Run '{run_name}' not found in {self.hdf5_path}")
+
+            self._unpack_group(runs_group[run_name], out_dir)
+
+        log.debug("Unpacked run '%s' to %s", run_name, out_dir)
+        return out_dir
+
+    def _unpack_group(self, group: 'h5py.Group', out_dir: str) -> None:
+        """
+        Recursively write an hdf5 group's contents out to `out_dir`.
+
+        Nested groups become subdirectories; datasets become files, written
+        as text or as raw bytes based on their "file_type" attribute (see
+        `pack_run_dir`).
+
+        Args:
+            group (h5py.Group): hdf5 group to unpack.
+            out_dir (str): Directory to write this group's contents into.
+                Created if it does not already exist.
+        """
+        os.makedirs(out_dir, exist_ok=True)
+
+        for name, item in group.items():
+            item_path = os.path.join(out_dir, name)
+
+            if isinstance(item, h5py.Group):
+                self._unpack_group(item, item_path)
+                continue
+
+            if item.attrs.get('file_type') == 'binary':
+                np.asarray(item[()], dtype=np.uint8).tofile(item_path)
+            else:
+                text = item[()]
+                if isinstance(text, bytes):
+                    text = text.decode('utf-8')
+                with open(item_path, 'w') as fh:
+                    fh.write(text)

--- a/src/enchanted_surrogates/packers/ascii_bin_to_hdf5_packer.py
+++ b/src/enchanted_surrogates/packers/ascii_bin_to_hdf5_packer.py
@@ -81,55 +81,22 @@ class AsciiBinToHdf5Packer(Packer):
         """
         Args:
             hdf5_path (str, optional): Path to the hdf5 file to pack into /
-                unpack from. If not given, defaults to the first available
-                path from `_default_hdf5_path` (`~/enchanted_data_packed.h5`,
-                falling back to `_1.h5`, `_2.h5`, etc. if it already exists).
+                unpack from. If not given, defaults to `base_run_dir/
+                enchanted_data_packed.h5` if `base_run_dir` is given,
+                otherwise falls back to the first available path from
+                `_default_hdf5_path` (`~/enchanted_data_packed.h5`, falling
+                back to `_1.h5`, `_2.h5`, etc. if it already exists).
         """
-        self._custom_hdf5_path = False
-        self._base_run_dir = None
-        self._hdf5_path = None
-
         super().__init__(**kwargs)
 
         self.base_run_dir = kwargs.get('base_run_dir')
         if kwargs.get('hdf5_path') is not None:
             self.hdf5_path = kwargs['hdf5_path']
         elif self.base_run_dir is not None:
+            os.makedirs(self.base_run_dir, exist_ok=True)
             self.hdf5_path = os.path.join(self.base_run_dir, 'enchanted_data_packed.h5')
         else:
             self.hdf5_path = _default_hdf5_path()
-
-    @property
-    def base_run_dir(self):
-        return self._base_run_dir
-
-    @base_run_dir.setter
-    def base_run_dir(self, value):
-        self._base_run_dir = value
-        if value is not None and not self._custom_hdf5_path:
-            os.makedirs(value, exist_ok=True)
-            self._hdf5_path = os.path.join(value, 'enchanted_data_packed.h5')
-
-    @property
-    def hdf5_path(self):
-        if self._hdf5_path is None:
-            if self._base_run_dir is not None and not self._custom_hdf5_path:
-                self._hdf5_path = os.path.join(self._base_run_dir, 'enchanted_data_packed.h5')
-            elif not self._custom_hdf5_path:
-                self._hdf5_path = _default_hdf5_path()
-        return self._hdf5_path
-
-    @hdf5_path.setter
-    def hdf5_path(self, value):
-        self._hdf5_path = value
-        self._custom_hdf5_path = value is not None
-
-    def _ensure_hdf5_path(self):
-        """Move the default output into base_run_dir if that info becomes available later."""
-        if self._custom_hdf5_path or self._base_run_dir is None:
-            return
-
-        self.base_run_dir = self._base_run_dir
 
     def pack_run_dir(self, run_dir: str, results: dict = None) -> None:
         """
@@ -160,7 +127,6 @@ class AsciiBinToHdf5Packer(Packer):
         Returns:
             None
         """
-        self._ensure_hdf5_path()
         run_dir = os.path.abspath(run_dir)
         run_name = os.path.basename(os.path.normpath(run_dir))
 

--- a/src/enchanted_surrogates/packers/ascii_bin_to_hdf5_packer.py
+++ b/src/enchanted_surrogates/packers/ascii_bin_to_hdf5_packer.py
@@ -85,8 +85,51 @@ class AsciiBinToHdf5Packer(Packer):
                 path from `_default_hdf5_path` (`~/enchanted_data_packed.h5`,
                 falling back to `_1.h5`, `_2.h5`, etc. if it already exists).
         """
+        self._custom_hdf5_path = False
+        self._base_run_dir = None
+        self._hdf5_path = None
+
         super().__init__(**kwargs)
-        self.hdf5_path = kwargs.get('hdf5_path') or _default_hdf5_path()
+
+        self.base_run_dir = kwargs.get('base_run_dir')
+        if kwargs.get('hdf5_path') is not None:
+            self.hdf5_path = kwargs['hdf5_path']
+        elif self.base_run_dir is not None:
+            self.hdf5_path = os.path.join(self.base_run_dir, 'enchanted_data_packed.h5')
+        else:
+            self.hdf5_path = _default_hdf5_path()
+
+    @property
+    def base_run_dir(self):
+        return self._base_run_dir
+
+    @base_run_dir.setter
+    def base_run_dir(self, value):
+        self._base_run_dir = value
+        if value is not None and not self._custom_hdf5_path:
+            os.makedirs(value, exist_ok=True)
+            self._hdf5_path = os.path.join(value, 'enchanted_data_packed.h5')
+
+    @property
+    def hdf5_path(self):
+        if self._hdf5_path is None:
+            if self._base_run_dir is not None and not self._custom_hdf5_path:
+                self._hdf5_path = os.path.join(self._base_run_dir, 'enchanted_data_packed.h5')
+            elif not self._custom_hdf5_path:
+                self._hdf5_path = _default_hdf5_path()
+        return self._hdf5_path
+
+    @hdf5_path.setter
+    def hdf5_path(self, value):
+        self._hdf5_path = value
+        self._custom_hdf5_path = value is not None
+
+    def _ensure_hdf5_path(self):
+        """Move the default output into base_run_dir if that info becomes available later."""
+        if self._custom_hdf5_path or self._base_run_dir is None:
+            return
+
+        self.base_run_dir = self._base_run_dir
 
     def pack_run_dir(self, run_dir: str, results: dict = None) -> None:
         """
@@ -117,6 +160,7 @@ class AsciiBinToHdf5Packer(Packer):
         Returns:
             None
         """
+        self._ensure_hdf5_path()
         run_dir = os.path.abspath(run_dir)
         run_name = os.path.basename(os.path.normpath(run_dir))
 

--- a/src/enchanted_surrogates/packers/base_packer.py
+++ b/src/enchanted_surrogates/packers/base_packer.py
@@ -13,7 +13,8 @@ class Packer(ABC):
     """
 
     def __init__(self, **kwargs):
-        pass
+        # this will be assigned by the supervisor and can be used by packers to determine the base run directory for relative paths
+        self.base_run_dir = kwargs.get("base_run_dir", None)
 
     @abstractmethod
     def pack_run_dir(self, run_dir: str, results: dict = None) -> dict:

--- a/src/enchanted_surrogates/packers/base_packer.py
+++ b/src/enchanted_surrogates/packers/base_packer.py
@@ -1,0 +1,39 @@
+from abc import ABC, abstractmethod
+
+
+class Packer(ABC):
+    """
+    Base class for packers that archive the contents of a run directory into
+    a single storage file (e.g. HDF5), and can later unpack a previously
+    archived run back out to disk.
+
+    Subclasses implement `pack_run_dir` (and, where it makes sense, an
+    `unpack_run_dir` counterpart) for a specific on-disk file layout and a
+    specific storage format.
+    """
+
+    def __init__(self, **kwargs):
+        pass
+
+    @abstractmethod
+    def pack_run_dir(self, run_dir: str, results: dict = None) -> dict:
+        """
+        Pack the contents of a single run directory into this packer's
+        storage file.
+
+        Args:
+            run_dir (str): Path to the run directory to pack.
+            results (dict, optional): Results previously parsed from
+                `run_dir` by some other parser (e.g. a runner's output
+                parser). Not every packer needs this - a packer that only
+                archives raw files is free to ignore it - but it is passed
+                through so packers that store parsed values alongside the
+                raw files (rather than re-parsing them) can use it. May also
+                be used to accumulate/return bookkeeping across repeated
+                calls; see individual subclasses for how they use it.
+
+        Returns:
+            dict: Bookkeeping about what was packed. Subclasses define the
+            exact contents.
+        """
+        raise NotImplementedError("Subclasses must implement this method")

--- a/src/enchanted_surrogates/supervisor/nested_imports.py
+++ b/src/enchanted_surrogates/supervisor/nested_imports.py
@@ -129,9 +129,19 @@ def import_packers(args) -> dict[str, Packer]:
     Returns:
         Dictionary mapping packer unique name to class instance
     """
+    supervisor_cfg = getattr(args, "supervisor", {}) or {}
+    base_run_dir = (
+        supervisor_cfg.get("base_run_dir")
+        if isinstance(supervisor_cfg, dict)
+        else getattr(supervisor_cfg, "get", lambda *args, **kwargs: None)("base_run_dir")
+    )
+
     packers = {}
     for name, packer_config in getattr(args, "packers", {}).items():
-        packers[name] = import_packer(packer_config["type"], packer_config)
+        packer_settings = dict(packer_config)
+        if base_run_dir is not None:
+            packer_settings.setdefault("base_run_dir", base_run_dir)
+        packers[name] = import_packer(packer_config["type"], packer_settings)
 
     return packers
 

--- a/src/enchanted_surrogates/supervisor/nested_imports.py
+++ b/src/enchanted_surrogates/supervisor/nested_imports.py
@@ -1,25 +1,28 @@
 """
-Utilies for importing multiple executors, samplers and runners.
+Utilies for importing multiple executors, samplers, runners and packers.
 """
 
 from dataclasses import dataclass
 from enchanted_surrogates.utils.logger import get_logger
 from enchanted_surrogates.executors.base_executor import Executor
 from enchanted_surrogates.samplers.base_sampler import Sampler
-from enchanted_surrogates.utils.precise_imports import import_sampler, import_executor
+from enchanted_surrogates.packers.base_packer import Packer
+from enchanted_surrogates.utils.precise_imports import import_sampler, import_executor, import_packer
 
 log = get_logger(__name__)
 
 @dataclass
 class RunGroup:
     """
-    Container for a group of executors, samplers, and runners. Represents one level of depth
-    in nested execution. If multiple executors or runners are defined, sequential execution is
-    (also) used.
+    Container for a group of executors, samplers, runners and packers. Represents one level of
+    depth in nested execution. If multiple executors or runners are defined, sequential
+    execution is (also) used. Packers are optional; a group with no packers configured has
+    `packers` set to None.
     """
     executors: list[Executor]
     sampler: Sampler
     runners: list[dict]
+    packers: list[Packer] | None = None
 
     def validate(self):
         """
@@ -33,19 +36,27 @@ class RunGroup:
             raise ValueError("At least one runner should be specified!")
         if not self.sampler:
             raise ValueError("Sampler should be specified!")
+        if self.packers is not None and len(self.packers) != len(self.runners):
+            raise ValueError(
+                "If packers are specified, the amount of packers and runners should be the same!"
+            )
 
 
-def parse_sequential_group(group_config: dict) -> tuple[str, list[str], list[str]]:
+def parse_sequential_group(
+    group_config: dict,
+) -> tuple[str, list[str], list[str], list[str] | None]:
     """
-    Parses sampler and sequential executors and runners from group config. Executors and runners
-    can be defined either as a single value or a list.
+    Parses sampler and sequential executors, runners and packers from group config. Executors,
+    runners and packers can be defined either as a single value or a list. Packers are optional:
+    if the group config has no "packer" key, no packer is used for this group.
 
     Args:
         group_config (dict): Configuration dictionary parsed from yaml
 
     Returns:
-        out (tuple[str, list[str], list[str]]): Tuple containg name of sampler, list of names
-            of executors and list of names of runners
+        out (tuple[str, list[str], list[str], list[str] | None]): Tuple containing name of
+            sampler, list of names of executors, list of names of runners and, if defined,
+            list of names of packers (None otherwise)
     """
     group_executors = (
         group_config["executor"]
@@ -58,10 +69,18 @@ def parse_sequential_group(group_config: dict) -> tuple[str, list[str], list[str
         if type(group_config["runner"]) is list
         else [group_config["runner"]]
     )
-    
+
+    group_packers = None
+    if "packer" in group_config:
+        group_packers = (
+            group_config["packer"]
+            if type(group_config["packer"]) is list
+            else [group_config["packer"]]
+        )
+
     sampler = group_config["sampler"]
 
-    return (sampler, group_executors, group_runners)
+    return (sampler, group_executors, group_runners, group_packers)
 
 
 def import_executors(args) -> dict[str, Executor]:
@@ -98,6 +117,25 @@ def import_samplers(args) -> dict[str, Sampler]:
     return samplers
 
 
+def import_packers(args) -> dict[str, Packer]:
+    """
+    Imports all packers from config, under 'packers' key. The 'packers' key is optional;
+    if it is not present in the config, an empty dict is returned and no run group will
+    have any packers.
+
+    Args:
+        args: Dictionary or namespace object, parsed from yaml
+
+    Returns:
+        Dictionary mapping packer unique name to class instance
+    """
+    packers = {}
+    for name, packer_config in getattr(args, "packers", {}).items():
+        packers[name] = import_packer(packer_config["type"], packer_config)
+
+    return packers
+
+
 def import_run_groups(args) -> list[dict]:
     """
     Imports supervisor/run_order from config.
@@ -124,15 +162,19 @@ def parse_all_run_groups(args) -> list[RunGroup]:
     """
     executors = import_executors(args)
     samplers = import_samplers(args)
+    packers = import_packers(args)
     group_configs = import_run_groups(args)
 
     nested_groups: list[RunGroup] = []
     for group in group_configs:
-        group_sampler, group_executors, group_runners = parse_sequential_group(group)
+        group_sampler, group_executors, group_runners, group_packers = parse_sequential_group(
+            group
+        )
         run_group = RunGroup(
             [executors[e] for e in group_executors],
             samplers[group_sampler],
             [{**args.runners[r], "__runner_name": r} for r in group_runners],
+            [packers[p] for p in group_packers] if group_packers is not None else None,
         )
 
         try:

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -531,6 +531,10 @@ class Supervisor:
                 if result is not None:
                     # remove so it is not rechecked and we are closer to while loop stopping
                     run_dirs.remove(run_dir)
+                    
+                    if self.data_packer is not None:
+                        self.data_packer.pack_run_dir(run_dir, result)
+                    
                     self.delete_unwanted_files(self.save_files_arg, run_dir, extra_keep_files=['enchanted_datapoint.csv'])
                     completed += 1
                     if result['success']:

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -161,6 +161,10 @@ class Supervisor:
                 for i, (executor, runner) in enumerate(
                     zip(group.executors, group.runners)
                 ):
+                    packer = None
+                    if group.packers is not None:
+                        packer = group.packers[i]
+                        packer.base_run_dir = self.base_run_dir  # Assign base_run_dir to packer
                     run_dirs = [
                         os.path.join(
                             real_run_dir, "data", f"d{depth}_b{batch_number}_s{j}_r{i}"
@@ -172,7 +176,7 @@ class Supervisor:
                     # monitor runs for failures and update progress file
                 
                     self.write_current_progress_string(depth, batch_number, len(run_dirs), 0, 0)
-                    self.monitor_runs(run_dirs, depth = depth, batch_number = batch_number)
+                    self.monitor_runs(run_dirs, depth = depth, batch_number = batch_number, packer=packer)
                     
                     # Wait processes of current batch to complete
                     self.wait_batch_dirs(run_dirs)
@@ -512,7 +516,7 @@ class Supervisor:
         while not self.batch_dirs_done(run_dirs):
             sleep(1)
     
-    def monitor_runs(self, run_dirs: list[str], depth, batch_number):
+    def monitor_runs(self, run_dirs: list[str], depth, batch_number, packer=None):
         log.debug('Monitoring runs...')
         """
         Keeps checking all the run_dirs for failures and logs the failures it finds
@@ -532,8 +536,8 @@ class Supervisor:
                     # remove so it is not rechecked and we are closer to while loop stopping
                     run_dirs.remove(run_dir)
                     
-                    if self.data_packer is not None:
-                        self.data_packer.pack_run_dir(run_dir, result)
+                    if packer is not None:
+                        packer.pack_run_dir(run_dir, result)
                     
                     self.delete_unwanted_files(self.save_files_arg, run_dir, extra_keep_files=['enchanted_datapoint.csv'])
                     completed += 1

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -164,7 +164,6 @@ class Supervisor:
                     packer = None
                     if group.packers is not None:
                         packer = group.packers[i]
-                        packer.base_run_dir = self.base_run_dir  # Assign base_run_dir to packer
                     run_dirs = [
                         os.path.join(
                             real_run_dir, "data", f"d{depth}_b{batch_number}_s{j}_r{i}"

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -174,7 +174,7 @@ class Supervisor:
                 ):
                     packer = None
                     if group.packers is not None:
-                        packer = group.packers[i]
+                        packer = group.packers[sequential_depth]
                     run_dirs = [
                         os.path.join(
                             real_run_dir, "data", f"dn{nested_depth}_ds{sequential_depth}_b{batch_number}_s{j}"

--- a/src/enchanted_surrogates/supervisor/supervisor.py
+++ b/src/enchanted_surrogates/supervisor/supervisor.py
@@ -185,15 +185,8 @@ class Supervisor:
                     self.update_runner_progress(f'G{nested_depth}', runner, submitted=len(expanded))
 
                     # monitor runs for failures and update progress file
-<<<<<<< HEAD
-                
-                    self.write_current_progress_string(depth, batch_number, len(run_dirs), 0, 0)
-                    self.monitor_runs(run_dirs, depth = depth, batch_number = batch_number, packer=packer)
-                    
-=======
-                    self.monitor_runs(f'G{nested_depth}', runner, run_dirs, nested_depth = nested_depth, sequential_depth = sequential_depth, batch_number = batch_number, group_start_time=group_start_time)
+                    self.monitor_runs(f'G{nested_depth}', runner, run_dirs, nested_depth = nested_depth, sequential_depth = sequential_depth, batch_number = batch_number, group_start_time=group_start_time, packer=packer)
 
->>>>>>> develop
                     # Wait processes of current batch to complete
                     self.wait_batch_dirs(run_dirs)
 
@@ -537,11 +530,7 @@ class Supervisor:
         while not self.batch_dirs_done(run_dirs):
             sleep(1)
     
-<<<<<<< HEAD
-    def monitor_runs(self, run_dirs: list[str], depth, batch_number, packer=None):
-=======
-    def monitor_runs(self, group_name, runner_config, run_dirs: list[str], nested_depth, sequential_depth, batch_number, group_start_time):
->>>>>>> develop
+    def monitor_runs(self, group_name, runner_config, run_dirs: list[str], nested_depth, sequential_depth, batch_number, group_start_time, packer=None):
         log.debug('Monitoring runs...')
         """
         Keeps checking all the run_dirs for failures and logs the failures it finds

--- a/src/enchanted_surrogates/utils/precise_imports.py
+++ b/src/enchanted_surrogates/utils/precise_imports.py
@@ -29,9 +29,9 @@ def detect_case_style(s):
 
     if "_" in s and s.lower() == s:
         return "snake_case"
-    elif re.match(r"^[a-z]+(?:[A-Z][a-z]*)+$", s):
+    elif re.match(r"^[a-z]+[0-9]*(?:[A-Z][a-z]*[0-9]*)+$", s):
         return "camelCase"
-    elif re.match(r"^[A-Z][a-z]+(?:[A-Z][a-z]*)*$", s):
+    elif re.match(r"^[A-Z][a-z]+[0-9]*(?:[A-Z][a-z]*[0-9]*)*$", s):
         return "PascalCase"
     elif "-" in s and s.lower() == s:
         return "kebab-case"
@@ -271,6 +271,31 @@ def import_executor(executor_type, executor_config):
     """
     executor = cached_import(executor_type, "executors")(**executor_config)
     return executor
+
+
+def import_packer(packer_type, packer_config):
+    """
+    Dynamically imports and instantiates a packer class based on naming convention.
+
+    Parameters
+    ----------
+    packer_type : str
+        The name of the packer (in snake_case or PascalCase).
+    packer_config : dict
+        Keyword arguments to pass to the packer constructor.
+
+    Returns
+    -------
+    object
+        An instance of the packer class.
+
+    Raises
+    ------
+    ImportError
+        If the module or class cannot be found.
+    """
+    packer = cached_import(packer_type, "packers")(**packer_config)
+    return packer
 
 
 def import_parser(parser_type, parser_config):

--- a/tests/supervisor/test_nested_imports.py
+++ b/tests/supervisor/test_nested_imports.py
@@ -1,0 +1,122 @@
+from types import SimpleNamespace
+import pytest
+
+from enchanted_surrogates.supervisor.nested_imports import (
+    parse_sequential_group,
+    import_packers,
+    parse_all_run_groups,
+    RunGroup,
+)
+
+
+def test_parse_sequential_group_without_packer():
+    group_config = {"sampler": "s1", "executor": "e1", "runner": "r1"}
+    sampler, executors, runners, packers = parse_sequential_group(group_config)
+
+    assert sampler == "s1"
+    assert executors == ["e1"]
+    assert runners == ["r1"]
+    assert packers is None
+
+
+def test_parse_sequential_group_with_single_packer():
+    group_config = {"sampler": "s1", "executor": "e1", "runner": "r1", "packer": "p1"}
+    _, _, _, packers = parse_sequential_group(group_config)
+
+    assert packers == ["p1"]
+
+
+def test_parse_sequential_group_with_packer_list():
+    group_config = {
+        "sampler": "s1",
+        "executor": ["e1", "e2"],
+        "runner": ["r1", "r2"],
+        "packer": ["p1", "p2"],
+    }
+    _, _, _, packers = parse_sequential_group(group_config)
+
+    assert packers == ["p1", "p2"]
+
+
+def test_import_packers_missing_section_returns_empty_dict():
+    # No 'packers' attribute at all - packers are optional at the top level.
+    args = SimpleNamespace(executors={}, samplers={}, runners={})
+
+    assert import_packers(args) == {}
+
+
+def test_import_packers_builds_instances(monkeypatch):
+    seen_configs = {}
+
+    def fake_import_packer(packer_type, packer_config):
+        seen_configs[packer_type] = packer_config
+        return f"packer-instance:{packer_type}"
+
+    monkeypatch.setattr(
+        "enchanted_surrogates.supervisor.nested_imports.import_packer",
+        fake_import_packer,
+    )
+
+    args = SimpleNamespace(
+        packers={"p1": {"type": "mock_packer", "hdf5_path": "/tmp/x.h5"}}
+    )
+
+    packers = import_packers(args)
+
+    assert packers == {"p1": "packer-instance:mock_packer"}
+    assert seen_configs == {"mock_packer": {"type": "mock_packer", "hdf5_path": "/tmp/x.h5"}}
+
+
+def test_parse_all_run_groups_wires_packers(monkeypatch):
+    monkeypatch.setattr(
+        "enchanted_surrogates.supervisor.nested_imports.import_executor",
+        lambda t, c: f"executor:{t}",
+    )
+    monkeypatch.setattr(
+        "enchanted_surrogates.supervisor.nested_imports.import_sampler",
+        lambda t, c: f"sampler:{t}",
+    )
+    monkeypatch.setattr(
+        "enchanted_surrogates.supervisor.nested_imports.import_packer",
+        lambda t, c: f"packer:{t}",
+    )
+
+    args = SimpleNamespace(
+        executors={"e1": {"type": "mock_executor"}},
+        samplers={"s1": {"type": "mock_sampler"}},
+        runners={"r1": {"type": "mock_runner"}},
+        packers={"p1": {"type": "mock_packer"}},
+        supervisor={
+            "run_order": [
+                {"sampler": "s1", "executor": "e1", "runner": "r1", "packer": "p1"},
+                {"sampler": "s1", "executor": "e1", "runner": "r1"},
+            ]
+        },
+    )
+
+    groups = parse_all_run_groups(args)
+
+    assert groups[0].packers == ["packer:mock_packer"]
+    assert groups[1].packers is None
+
+
+def test_run_group_validate_raises_on_packer_runner_count_mismatch():
+    group = RunGroup(
+        executors=["e1"],
+        sampler="s1",
+        runners=[{"type": "r1"}],
+        packers=["p1", "p2"],
+    )
+
+    with pytest.raises(ValueError, match="packers and runners"):
+        group.validate()
+
+
+def test_run_group_validate_passes_with_no_packers():
+    group = RunGroup(
+        executors=["e1"],
+        sampler="s1",
+        runners=[{"type": "r1"}],
+    )
+
+    group.validate()

--- a/tests/utils/test_precise_imports.py
+++ b/tests/utils/test_precise_imports.py
@@ -1,12 +1,15 @@
 import importlib
 from types import SimpleNamespace
 import pytest
+import enchanted_surrogates.utils.precise_imports as precise_imports
 from enchanted_surrogates.utils.precise_imports import (
-    clear_import_cache, cached_import, import_executor, import_sampler, import_runner
+    clear_import_cache, cached_import, import_executor, import_sampler, import_runner,
+    import_packer
 )
 from enchanted_surrogates.executors import LocalExecutor
 from enchanted_surrogates.samplers.random_sampler import RandomSampler
 from enchanted_surrogates.runners.example_runner import ExampleRunner
+from enchanted_surrogates.packers.ascii_bin_to_hdf5_packer import AsciiBinToHdf5Packer
 
 @pytest.mark.parametrize(
     "import_function, type_name, config, expected_type",
@@ -28,9 +31,15 @@ from enchanted_surrogates.runners.example_runner import ExampleRunner
             "ExampleRunner",
             {},
             ExampleRunner
+        ),
+        (
+            import_packer,
+            "AsciiBinToHdf5Packer",
+            {},
+            AsciiBinToHdf5Packer
         )
     ],
-    ids=["executor", "sampler", "runner"]
+    ids=["executor", "sampler", "runner", "packer"]
 )
 def test_import_instantiates_new_objects(
     import_function,
@@ -64,7 +73,8 @@ def test_cached_import_caches_results(monkeypatch):
         importlib, "import_module", mock_import_module
     )
     monkeypatch.setattr(
-        "enchanted_surrogates.utils.precise_imports.load_plugins",
+        precise_imports,
+        "load_plugins",
         lambda: {}
     )
 

--- a/workflow_tests/automated_tests_no_HPC/test_configs/nested_sequential_with_packer.yaml
+++ b/workflow_tests/automated_tests_no_HPC/test_configs/nested_sequential_with_packer.yaml
@@ -1,0 +1,53 @@
+executors:
+  e1: 
+    type: LocalExecutor
+  e2:
+    type: LocalExecutor
+samplers:
+  s1: 
+    type: RandomSampler
+    bounds: [[5, 5], [1, 1]] # So c1=5 and c2=1 always
+    budget: 10
+    batch_size: 1
+    parameters: ['c1', 'c2']
+  s2: 
+    type: RandomSampler
+    bounds: [[3, 3], [2, 2]] # So c3=3 and c4=2 always
+    budget: 10
+    batch_size: 1
+    parameters: ['c3', 'c4']
+
+packers:
+  p1:
+    type: AsciiBinToHdf5Packer
+
+runners:
+  r1:
+    type: SumRunner
+    params_to_sum: [c1, c2, c3, c4]
+  r2:
+    type: SumRunner 
+    params_to_sum: [output, c1, c2, c3, c4]
+supervisor:
+  base_run_dir: tmp_path
+  run_order:
+  - sampler: s1
+    executor:
+    - e1
+    - e2
+    runner:
+    - r1
+    - r2
+    packer:
+    - p1
+    - p1
+  - sampler: s2
+    executor:
+    - e2
+    - e1
+    runner:
+    - r1
+    - r2
+    packer:
+    - p1
+    - p1

--- a/workflow_tests/automated_tests_no_HPC/test_sequential_workflow.py
+++ b/workflow_tests/automated_tests_no_HPC/test_sequential_workflow.py
@@ -2,8 +2,11 @@
 Basic tests for the sequential workflow.
 """
 
+from pathlib import Path
+
 import pytest
 from workflow_tests.utils.test_utils import *
+from enchanted_surrogates.packers.ascii_bin_to_hdf5_packer import AsciiBinToHdf5Packer
 from enchanted_surrogates.supervisor.supervisor import Supervisor
 
 def test_sequential_workflow(tmp_path, run_config):
@@ -52,3 +55,29 @@ def test_nested_sequential_workflow(tmp_path, run_config):
     # All results after second nested run will be 12+10
     for row in summary:
         assert row["output"] == pytest.approx(22.0)
+
+
+def test_nested_sequential_workflow_with_packer(tmp_path, run_config):
+    supervisor = run_config("test_configs/nested_sequential_with_packer.yaml", call_start=False)
+
+    packed_hdf5 = tmp_path / "packed_runs.h5"
+    for group in supervisor.nested_groups:
+        if group.packers is not None:
+            for packer in group.packers:
+                packer.hdf5_path = str(packed_hdf5)
+
+    supervisor.start()
+
+    assert len(supervisor.nested_groups) == 2
+    assert get_run_dir_count(tmp_path / "data") > 0
+    assert len(read_summary_file(tmp_path)) > 0
+    assert packed_hdf5.exists()
+
+    first_run_dir = next((path for path in (tmp_path / "data").iterdir() if path.is_dir()), None)
+    assert first_run_dir is not None
+
+    packer = AsciiBinToHdf5Packer(hdf5_path=str(packed_hdf5))
+    unpacked_dir = packer.unpack_run_dir(str(first_run_dir), str(tmp_path / "unpacked"))
+
+    assert Path(unpacked_dir).exists()
+    assert any(Path(unpacked_dir).iterdir())

--- a/workflow_tests/automated_tests_no_HPC/test_simple_workflow.py
+++ b/workflow_tests/automated_tests_no_HPC/test_simple_workflow.py
@@ -17,3 +17,4 @@ def test_full_workflow(tmp_path, run_config, config_file):
     # This should create {budget} folders
     assert get_run_dir_count(tmp_path / "data") == run_group.sampler.budget
     assert len(read_summary_file(tmp_path)) == run_group.sampler.budget
+


### PR DESCRIPTION
Now a user can have a script which packs each run_dir into a single file as soon as each run is complete. A different packer can be defined for each runner so the packers can be code specific. 

It is fully integrated with the current pipeline, including precise imports, docs and tests. 

I have been using it and it has been working smoothly. 