### PR TITLE
Route SLURM worker stdout/stderr into the run's log directory

### DIFF
--- a/src/enchanted_surrogates/executors/dask_executor.py
+++ b/src/enchanted_surrogates/executors/dask_executor.py
@@ -390,6 +390,7 @@ class DaskExecutor(Executor):
                 self.expected_number_of_workers = self.scale_n_jobs_min * int(self.SLURMcluster_config.get('processes',1))
 
             log.info(f"Output of SLURM workers saved in: {slurm_out_dir}")
+            self.SLURMcluster_config.setdefault("log_directory", slurm_out_dir)
             self.cluster = SLURMCluster(silence_logs=False, **self.SLURMcluster_config)
             self.cluster.scale(self.scale_n_jobs)
             


### PR DESCRIPTION
dask_jobqueue defaults slurm-<jobid>.out files to the submission cwd, cluttering the launch directory. Point them at the same log_directory used for per-worker application logs instead.